### PR TITLE
✨feat: Open AI API 연동 및 프롬프트 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,16 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('springCloudVersion', '2024.0.0')
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -31,6 +41,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/main/java/com/be_notemasterai/BeNoteMasterAiApplication.java
+++ b/src/main/java/com/be_notemasterai/BeNoteMasterAiApplication.java
@@ -2,10 +2,12 @@ package com.be_notemasterai;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableFeignClients
 public class BeNoteMasterAiApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/be_notemasterai/config/OpenAiConfig.java
+++ b/src/main/java/com/be_notemasterai/config/OpenAiConfig.java
@@ -1,0 +1,17 @@
+package com.be_notemasterai.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "openai")
+@Getter
+@Setter
+public class OpenAiConfig {
+
+  private String apiKey;
+  private String model;
+  private String baseUrl;
+}

--- a/src/main/java/com/be_notemasterai/note/entity/Note.java
+++ b/src/main/java/com/be_notemasterai/note/entity/Note.java
@@ -1,0 +1,66 @@
+package com.be_notemasterai.note.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.be_notemasterai.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@Table(name = "notes")
+@EntityListeners(AuditingEntityListener.class)
+public class Note {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  @JoinColumn(name = "owner_id", nullable = false)
+  @ManyToOne(fetch = LAZY)
+  private Member owner;
+
+  @Column(nullable = false)
+  private String title;
+
+  @Column(name = "original_text", nullable = false, columnDefinition = "TEXT")
+  private String originalText;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String summary;
+
+  @CreatedDate
+  @Column(name = "created_at")
+  private LocalDateTime createdAt;
+
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
+
+  public static Note of(Member owner, String title, String originalText, String summary) {
+
+    return Note.builder()
+        .owner(owner)
+        .title(title)
+        .originalText(originalText)
+        .summary(summary)
+        .build();
+  }
+}

--- a/src/main/java/com/be_notemasterai/note/repository/NoteRepository.java
+++ b/src/main/java/com/be_notemasterai/note/repository/NoteRepository.java
@@ -1,0 +1,8 @@
+package com.be_notemasterai.note.repository;
+
+import com.be_notemasterai.note.entity.Note;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoteRepository extends JpaRepository<Note, Long> {
+
+}

--- a/src/main/java/com/be_notemasterai/note/service/NoteService.java
+++ b/src/main/java/com/be_notemasterai/note/service/NoteService.java
@@ -1,0 +1,22 @@
+package com.be_notemasterai.note.service;
+
+import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.note.entity.Note;
+import com.be_notemasterai.note.repository.NoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoteService {
+
+  private final NoteRepository noteRepository;
+
+  @Transactional
+  public void createNote(Member owner, String title, String originalText, String summary) {
+
+    noteRepository.save(Note.of(owner, title, originalText, summary));
+  }
+}

--- a/src/main/java/com/be_notemasterai/openai/client/OpenAiClient.java
+++ b/src/main/java/com/be_notemasterai/openai/client/OpenAiClient.java
@@ -1,0 +1,16 @@
+package com.be_notemasterai.openai.client;
+
+import com.be_notemasterai.openai.dto.OpenAiRequest;
+import com.be_notemasterai.openai.dto.OpenAiResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "openAiClient", url = "${openai.base-url}")
+public interface OpenAiClient {
+
+  @PostMapping
+  OpenAiResponse getSummary(@RequestHeader("Authorization") String apiKey,
+      @RequestBody OpenAiRequest request);
+}

--- a/src/main/java/com/be_notemasterai/openai/controller/AiSummaryController.java
+++ b/src/main/java/com/be_notemasterai/openai/controller/AiSummaryController.java
@@ -1,0 +1,31 @@
+package com.be_notemasterai.openai.controller;
+
+import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.openai.dto.SummaryRequest;
+import com.be_notemasterai.openai.dto.SummaryResponse;
+import com.be_notemasterai.openai.service.OpenAiService;
+import com.be_notemasterai.security.resolver.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/summary")
+public class AiSummaryController {
+
+  private final OpenAiService openAiService;
+
+  @PostMapping
+  public ResponseEntity<SummaryResponse> summarize(
+      @RequestBody SummaryRequest summaryRequest,
+      @CurrentMember Member member) {
+
+    SummaryResponse summaryResponse = openAiService.summarize(summaryRequest, member);
+
+    return ResponseEntity.ok(summaryResponse);
+  }
+}

--- a/src/main/java/com/be_notemasterai/openai/dto/OpenAiRequest.java
+++ b/src/main/java/com/be_notemasterai/openai/dto/OpenAiRequest.java
@@ -1,0 +1,14 @@
+package com.be_notemasterai.openai.dto;
+
+import com.be_notemasterai.config.OpenAiConfig;
+import java.util.List;
+import java.util.Map;
+
+public record OpenAiRequest(String model, List<Map<String, String>> messages) {
+
+  public static OpenAiRequest of(OpenAiConfig openAiConfig, String prompt) {
+
+    return new OpenAiRequest(openAiConfig.getModel(),
+        List.of(Map.of("role", "user", "content", prompt)));
+  }
+}

--- a/src/main/java/com/be_notemasterai/openai/dto/OpenAiResponse.java
+++ b/src/main/java/com/be_notemasterai/openai/dto/OpenAiResponse.java
@@ -1,0 +1,10 @@
+package com.be_notemasterai.openai.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record OpenAiResponse(List<Choice> choices) {
+
+  public record Choice(Map<String, String> message) {
+  }
+}

--- a/src/main/java/com/be_notemasterai/openai/dto/SummaryRequest.java
+++ b/src/main/java/com/be_notemasterai/openai/dto/SummaryRequest.java
@@ -1,0 +1,4 @@
+package com.be_notemasterai.openai.dto;
+
+public record SummaryRequest(String text) {
+}

--- a/src/main/java/com/be_notemasterai/openai/dto/SummaryResponse.java
+++ b/src/main/java/com/be_notemasterai/openai/dto/SummaryResponse.java
@@ -1,0 +1,4 @@
+package com.be_notemasterai.openai.dto;
+
+public record SummaryResponse(String summaryResponse) {
+}

--- a/src/main/java/com/be_notemasterai/openai/service/OpenAiService.java
+++ b/src/main/java/com/be_notemasterai/openai/service/OpenAiService.java
@@ -1,0 +1,128 @@
+package com.be_notemasterai.openai.service;
+
+import static com.be_notemasterai.subscribe.type.SubscriptionStatus.ACTIVE;
+import static java.util.regex.Pattern.MULTILINE;
+
+import com.be_notemasterai.config.OpenAiConfig;
+import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.note.service.NoteService;
+import com.be_notemasterai.openai.client.OpenAiClient;
+import com.be_notemasterai.openai.dto.OpenAiRequest;
+import com.be_notemasterai.openai.dto.OpenAiResponse;
+import com.be_notemasterai.openai.dto.SummaryRequest;
+import com.be_notemasterai.openai.dto.SummaryResponse;
+import com.be_notemasterai.subscribe.repository.SubscribeRepository;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OpenAiService {
+
+  private final OpenAiClient openAiClient;
+
+  private final OpenAiConfig openAiConfig;
+
+  private final SubscribeRepository subscribeRepository;
+
+  private final NoteService noteService;
+
+  @Transactional
+  public SummaryResponse summarize(SummaryRequest summaryRequest, Member member) {
+
+    boolean isSubscriber = checkSubscriptionStatus(member);
+
+    String prompt = generatePrompt(isSubscriber, summaryRequest.text());
+
+    String summary = requestOpenAiSummary(prompt);
+
+    String generatedTitle = extractTitle(summary);
+
+    noteService.createNote(member, generatedTitle, summaryRequest.text(), summary);
+
+    return new SummaryResponse(summary);
+  }
+
+  private boolean checkSubscriptionStatus(Member member) {
+    return subscribeRepository.existsBySubscriberIdAndSubscriptionStatus(member.getId(), ACTIVE);
+  }
+
+  private String generatePrompt(boolean isSubscriber, String text) {
+    return getPromptBasedOnPlan(isSubscriber, text);
+  }
+
+  private String getPromptBasedOnPlan(boolean isSubscriber, String text) {
+
+    if (isSubscriber) {
+
+      return """
+          ### 역할
+          1. 너는 GPT 4o 모델 스타일로 답변하는 AI 기반 문서 분석 전문가야.
+          2. 다음 문서를 읽고, 논리적으로 구조화된 요약을 생성해줘.
+          3. 답변할 때 무조건 적절한 이모지를 풍부하고 자주 사용해서 독자가 쉽게 이해할 수 있도록 답변해줘.
+          4. 답변의 형식은 반드시 Markdown 형식으로 제공해야 돼.
+
+          ### 요약 목표
+          1. 각 섹션별 상세 요약(문서 내용의 핵심을 충분히 포함)
+          2. 숫자, 통계, 날짜, 주요 정보 등을 강조
+          3. 독자가 쉽게 이해할 수 있도록 요약문을 정리
+          4. 필요한 경우 표 형식으로 정리
+          5. 논리적이고 직관적으로 알기 쉽게 정리
+
+          ### 요약 포맷
+          1. **제목**
+          2. 📌 **전체 정리**: %s
+          3. 🔍 **결론**
+          4. ✅ **포인트 정리**
+          5. 📖 **단락별 요약**
+          """.formatted(text);
+    } else {
+
+      return """
+          너는 GPT 4o 모델 스타일로 답변하는 AI 기반 문서 분석 전문가야.
+          다음 문서를 읽고 짧고 간결한 요약을 제공해줘.
+
+          ### 요약 목표
+          1. 문서의 핵심만 간략하게 정리 (1~3문장 이내)
+          2. 불필요한 내용은 제외하고 본질적인 정보만 제공
+          3. 독자가 빠르게 이해할 수 있도록 쉬운 문장으로 작성
+
+          ### 요약 포맷
+          1. **제목**
+          2. **한 줄 요약**: %s
+          3. **핵심 정보**: 중요한 숫자, 날짜, 키워드만 정리
+          """.formatted(text);
+    }
+  }
+
+  private String requestOpenAiSummary(String prompt) {
+
+    OpenAiRequest openAiRequest = OpenAiRequest.of(openAiConfig, prompt);
+
+    OpenAiResponse openAiResponse = openAiClient.getSummary("Bearer " + openAiConfig.getApiKey(),
+        openAiRequest);
+
+    return openAiResponse.choices().get(0).message().get("content");
+  }
+
+  private String extractTitle(String summary) {
+
+    Pattern pattern = Pattern.compile("^(?:1\\.\\s\\*\\*(.*?)\\*\\*|#\\s*(.+?)\\n|##\\s*(.+?)\\n)",
+        MULTILINE);
+    Matcher matcher = pattern.matcher(summary);
+
+    if (matcher.find()) {
+      if (matcher.group(1) != null) {
+        return matcher.group(1).trim();
+      } else if (matcher.group(2) != null) {
+        return matcher.group(2).trim();
+      } else if (matcher.group(3) != null) {
+        return matcher.group(3).trim();
+      }
+    }
+    return "자동 생성된 제목";
+  }
+}

--- a/src/main/java/com/be_notemasterai/subscribe/entity/Subscribe.java
+++ b/src/main/java/com/be_notemasterai/subscribe/entity/Subscribe.java
@@ -1,0 +1,60 @@
+package com.be_notemasterai.subscribe.entity;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.subscribe.type.SubscriptionStatus;
+import com.be_notemasterai.subscribe.type.SubscriptionType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Subscribe {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  @JoinColumn(name = "subscriber_id", nullable = false)
+  @ManyToOne(fetch = LAZY)
+  private Member subscriber;
+
+  @Column(name = "payment_id", nullable = false)
+  private Long paymentId;
+
+  @Column(name = "subscription_type", nullable = false)
+  @Enumerated(STRING)
+  private SubscriptionType subscriptionType;
+
+  @Column(name = "subscription_status", nullable = false)
+  @Enumerated(STRING)
+  private SubscriptionStatus subscriptionStatus;
+
+  @CreatedDate
+  @Column(name = "started_at")
+  private LocalDateTime startedAt;
+
+  @Column(name = "ended_at")
+  private LocalDateTime endedAt;
+}

--- a/src/main/java/com/be_notemasterai/subscribe/repository/SubscribeRepository.java
+++ b/src/main/java/com/be_notemasterai/subscribe/repository/SubscribeRepository.java
@@ -1,0 +1,10 @@
+package com.be_notemasterai.subscribe.repository;
+
+import com.be_notemasterai.subscribe.entity.Subscribe;
+import com.be_notemasterai.subscribe.type.SubscriptionStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
+
+  boolean existsBySubscriberIdAndSubscriptionStatus(Long memberId, SubscriptionStatus subscriptionStatus);
+}

--- a/src/main/java/com/be_notemasterai/subscribe/type/SubscriptionStatus.java
+++ b/src/main/java/com/be_notemasterai/subscribe/type/SubscriptionStatus.java
@@ -1,0 +1,5 @@
+package com.be_notemasterai.subscribe.type;
+
+public enum SubscriptionStatus {
+  ACTIVE, CANCELLED
+}

--- a/src/main/java/com/be_notemasterai/subscribe/type/SubscriptionType.java
+++ b/src/main/java/com/be_notemasterai/subscribe/type/SubscriptionType.java
@@ -1,0 +1,5 @@
+package com.be_notemasterai.subscribe.type;
+
+public enum SubscriptionType {
+  MONTH, YEAR
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,3 +42,7 @@ spring.security.oauth2.client.provider.naver.user-info-uri=https://openapi.naver
 spring.security.oauth2.client.provider.naver.user-name-attribute=response
 
 jwt.secret=${JWT_SECRET}
+
+openai.api-key=${OPEN_AI_API_KEY}
+openai.model=${GPT_MODEL}
+openai.base-url=${OPEN_AI_BASE_URL}

--- a/src/test/java/com/be_notemasterai/note/service/NoteServiceTest.java
+++ b/src/test/java/com/be_notemasterai/note/service/NoteServiceTest.java
@@ -1,0 +1,48 @@
+package com.be_notemasterai.note.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.note.entity.Note;
+import com.be_notemasterai.note.repository.NoteRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NoteServiceTest {
+
+  @Mock
+  private NoteRepository noteRepository;
+
+  @InjectMocks
+  private NoteService noteService;
+
+  private Member member;
+
+  @BeforeEach
+  void setUp() {
+    member = Member.builder()
+        .provider("google")
+        .providerUuid("providerUuid")
+        .name("이름")
+        .profileImageUrl("프로필이미지")
+        .tag("태그")
+        .build();
+  }
+
+  @Test
+  @DisplayName("노트가 성공적으로 생성된다")
+  void createNote_success() {
+    // given
+    // when
+    noteService.createNote(member, "제목", "원본", "요약");
+    // then
+    verify(noteRepository).save(any(Note.class));
+  }
+}

--- a/src/test/java/com/be_notemasterai/openai/service/OpenAiServiceTest.java
+++ b/src/test/java/com/be_notemasterai/openai/service/OpenAiServiceTest.java
@@ -1,0 +1,76 @@
+package com.be_notemasterai.openai.service;
+
+import static com.be_notemasterai.subscribe.type.SubscriptionStatus.ACTIVE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.be_notemasterai.config.OpenAiConfig;
+import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.note.service.NoteService;
+import com.be_notemasterai.openai.client.OpenAiClient;
+import com.be_notemasterai.openai.dto.OpenAiRequest;
+import com.be_notemasterai.openai.dto.OpenAiResponse;
+import com.be_notemasterai.openai.dto.OpenAiResponse.Choice;
+import com.be_notemasterai.openai.dto.SummaryRequest;
+import com.be_notemasterai.openai.dto.SummaryResponse;
+import com.be_notemasterai.subscribe.repository.SubscribeRepository;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OpenAiServiceTest {
+
+  @Mock
+  private OpenAiClient openAiClient;
+
+  @Mock
+  private OpenAiConfig openAiConfig;
+
+  @Mock
+  private SubscribeRepository subscribeRepository;
+
+  @Mock
+  private NoteService noteService;
+
+  @InjectMocks
+  private OpenAiService openAiService;
+
+  private Member member;
+
+  @BeforeEach
+  void setUp() {
+    member = Member.builder()
+        .id(1L)
+        .provider("google")
+        .providerUuid("providerUuid")
+        .name("이름")
+        .profileImageUrl("프로필이미지")
+        .tag("태그")
+        .build();
+  }
+
+  @Test
+  @DisplayName("AI 요약이 정상적으로 성공한다")
+  void summarize_success() {
+    // given
+    SummaryRequest request = new SummaryRequest("원본");
+    OpenAiResponse openAiResponse = new OpenAiResponse(List.of(new Choice(Map.of("content", "요약"))));
+
+    when(openAiConfig.getModel()).thenReturn("gpt-4o-mini");
+    when(openAiClient.getSummary(anyString(), any(OpenAiRequest.class))).thenReturn(openAiResponse);
+    when(subscribeRepository.existsBySubscriberIdAndSubscriptionStatus(member.getId(), ACTIVE)).thenReturn(true);
+    // when
+    SummaryResponse response = openAiService.summarize(request, member);
+    // then
+    assertEquals("요약", response.summaryResponse());
+  }
+}


### PR DESCRIPTION
## 🛠️ 작업 내용 (What)
- Open AI API 연동 및 프롬프트 설정
## 📌 작업 이유 (Why)
- 서비스 핵심 기능인 AI 요약 구현
## ✨ 변경 사항 (Changes)
- OpenAI API 를 사용하기 위한 모델 및 API Key 설정
- HTTP API 요청을 쉽고 간편하게 사용하기 위해 OpenFeign 사용
- 사용자가 원본을 입력하면 -> AI 가 요약 후 -> Note 에 저장 후에 -> 사용자에게 반환
- 사용자의 유료 결제 여부에 따라 GPT 프롬프트 별도 제공
## ✅ 테스트 (Tests)
- [ ] 노트가 성공적으로 생성된다
- [ ] AI 요약이 정상적으로 성공한다