### PR TITLE
✨feat: Port One API 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 ext {
@@ -42,6 +43,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/main/java/com/be_notemasterai/config/PortOneConfig.java
+++ b/src/main/java/com/be_notemasterai/config/PortOneConfig.java
@@ -1,0 +1,23 @@
+package com.be_notemasterai.config;
+
+import com.siot.IamportRestClient.IamportClient;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "portone.api")
+@Getter
+@Setter
+public class PortOneConfig {
+
+  private String key;
+  private String secret;
+
+  @Bean
+  public IamportClient iamportClient() {
+    return new IamportClient(key, secret);
+  }
+}

--- a/src/main/java/com/be_notemasterai/config/SchedulerConfig.java
+++ b/src/main/java/com/be_notemasterai/config/SchedulerConfig.java
@@ -1,0 +1,23 @@
+package com.be_notemasterai.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+
+  @Bean
+  public TaskScheduler taskScheduler() {
+
+    ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+    taskScheduler.setPoolSize(10);
+    taskScheduler.setThreadNamePrefix("TaskScheduler-");
+    taskScheduler.initialize();
+
+    return taskScheduler;
+  }
+}

--- a/src/main/java/com/be_notemasterai/exception/ErrorCode.java
+++ b/src/main/java/com/be_notemasterai/exception/ErrorCode.java
@@ -18,18 +18,26 @@ public enum ErrorCode {
   INVALID_PROVIDER(BAD_REQUEST, "지원하지 않는 소셜 로그인입니다."),
   ALREADY_SET_NICKNAME(BAD_REQUEST, "이미 닉네임이 설정되었습니다."),
   EMPTY_SOUND_FILE(BAD_REQUEST, "음성파일이 업로드 되지 않았습니다."),
+  STATUS_NOT_PAID(BAD_REQUEST, "결제 상태가 paid 가 아닙니다."),
+  INVALID_AMOUNT(BAD_REQUEST, "결제 금액이 일치하지 않습니다."),
   // 401 UNAUTHORIZED
   INVALID_TOKEN(UNAUTHORIZED, "유효하지 않은 토큰입니다."),
   INVALID_REFRESH_TOKEN(UNAUTHORIZED, "리프레쉬 토큰이 유효하지 않습니다."),
   // 403 FORBIDDEN
   NOT_SUBSCRIBER(FORBIDDEN, "구독자만 접근 가능합니다."),
+  PAYMENT_OWNER_MISMATCH(FORBIDDEN, "결제정보가 일치하지 않습니다."),
   // 404 NOT FOUND
   NOT_FOUND_MEMBER(NOT_FOUND, "회원 정보가 없습니다."),
+  NOT_FOUND_PAYMENT(NOT_FOUND, "결제 정보가 없습니다."),
+  NOT_FOUND_SUBSCRIPTION(NOT_FOUND, "구독 내역을 확인할 수 없습니다."),
   // 408 REQUEST TIMEOUT
 
   // 409 CONFLICT
   EXISTS_NICKNAME(CONFLICT, "이미 존재하는 닉네임 입니다."),
+  ALREADY_REFUNDED(CONFLICT, "이미 환불되었습니다."),
   // 500 INTERNAL SERVER ERROR
+  FAILED_VALID_PAYMENT(HttpStatus.INTERNAL_SERVER_ERROR, "결제 검증에 실패하였습니다."),
+  FAILED_REFUND_PAYMENT(HttpStatus.INTERNAL_SERVER_ERROR, "결제 환불에 실패하였습니다."),
   FAILED_TO_STT(HttpStatus.INTERNAL_SERVER_ERROR, "음성 파일 읽는 중 오류가 발생했습니다."),
   FAILED_STT_PARSING(HttpStatus.INTERNAL_SERVER_ERROR, "음성 파일 파싱 중 오류가 발생했습니다."),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");

--- a/src/main/java/com/be_notemasterai/member/controller/AuthController.java
+++ b/src/main/java/com/be_notemasterai/member/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.be_notemasterai.member.controller;
 
+import com.be_notemasterai.member.dto.AccessTokenResponse;
 import com.be_notemasterai.member.service.AuthService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -17,14 +18,13 @@ public class AuthController {
 
   private final AuthService authService;
 
-  @PostMapping("/refresh")
-  public ResponseEntity<Void> refreshAccessToken(
-      @CookieValue(value = "refreshToken", required = false) String refreshToken,
-      HttpServletResponse response) {
+  @PostMapping("/token")
+  public ResponseEntity<AccessTokenResponse> refreshAccessToken(
+      @CookieValue(value = "refreshToken", required = false) String refreshToken) {
 
-    authService.refreshAccessToken(refreshToken, response);
+    AccessTokenResponse accessToken = authService.refreshAccessToken(refreshToken);
 
-    return ResponseEntity.ok().build();
+    return ResponseEntity.ok(accessToken);
   }
 
   @DeleteMapping("sign-out")

--- a/src/main/java/com/be_notemasterai/member/dto/AccessTokenResponse.java
+++ b/src/main/java/com/be_notemasterai/member/dto/AccessTokenResponse.java
@@ -1,0 +1,4 @@
+package com.be_notemasterai.member.dto;
+
+public record AccessTokenResponse(String accessToken) {
+}

--- a/src/main/java/com/be_notemasterai/member/service/AuthService.java
+++ b/src/main/java/com/be_notemasterai/member/service/AuthService.java
@@ -4,6 +4,7 @@ import static com.be_notemasterai.exception.ErrorCode.INVALID_REFRESH_TOKEN;
 import static com.be_notemasterai.exception.ErrorCode.INVALID_TOKEN;
 
 import com.be_notemasterai.exception.CustomException;
+import com.be_notemasterai.member.dto.AccessTokenResponse;
 import com.be_notemasterai.security.jwt.JwtTokenProvider;
 import com.be_notemasterai.security.jwt.JwtTokenService;
 import com.be_notemasterai.security.oauth2.CustomOAuth2UserService;
@@ -23,7 +24,7 @@ public class AuthService {
 
   private final CustomOAuth2UserService customOAuth2UserService;
 
-  public void refreshAccessToken(String refreshToken, HttpServletResponse response) {
+  public AccessTokenResponse refreshAccessToken(String refreshToken) {
 
     if (refreshToken == null || refreshToken.isEmpty()) {
       throw new CustomException(INVALID_REFRESH_TOKEN);
@@ -41,7 +42,7 @@ public class AuthService {
 
     String newAccessToken = jwtTokenProvider.createAccessToken(providerUuid);
 
-    response.addHeader("Set-Cookie", jwtTokenService.createAccessCookie(newAccessToken).toString());
+    return new AccessTokenResponse(newAccessToken);
   }
 
   public void signOut(String refreshToken, HttpServletResponse response) {
@@ -52,7 +53,6 @@ public class AuthService {
       jwtTokenService.deleteRefreshToken(providerUuid);
     }
 
-    response.addHeader("Set-Cookie", jwtTokenService.createExpiredCookie("accessToken").toString());
     response.addHeader("Set-Cookie", jwtTokenService.createExpiredCookie("refreshToken").toString());
   }
 }

--- a/src/main/java/com/be_notemasterai/payment/controller/PaymentController.java
+++ b/src/main/java/com/be_notemasterai/payment/controller/PaymentController.java
@@ -1,0 +1,48 @@
+package com.be_notemasterai.payment.controller;
+
+import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.payment.dto.PaymentRequest;
+import com.be_notemasterai.payment.dto.PrepareRequest;
+import com.be_notemasterai.payment.dto.RefundRequest;
+import com.be_notemasterai.payment.service.PaymentService;
+import com.be_notemasterai.security.resolver.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/payments")
+public class PaymentController {
+
+  private final PaymentService paymentService;
+
+  @PostMapping("/prepare")
+  public ResponseEntity<Void> preparePayment(@RequestBody PrepareRequest prepareRequest) {
+
+    paymentService.preparePayment(prepareRequest);
+
+    return ResponseEntity.ok().build();
+  }
+
+  @PostMapping("/verify")
+  public ResponseEntity<Void> verifyAndSavePayment(@CurrentMember Member member,
+      @RequestBody PaymentRequest paymentRequest) {
+
+    paymentService.verifyAndSavePayment(member, paymentRequest);
+
+    return ResponseEntity.ok().build();
+  }
+
+  @PostMapping("/refund")
+  public ResponseEntity<Void> refundPayment(@CurrentMember Member member,
+      @RequestBody RefundRequest refundRequest) {
+
+    paymentService.refundPayment(member, refundRequest);
+
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/be_notemasterai/payment/dto/PaymentRequest.java
+++ b/src/main/java/com/be_notemasterai/payment/dto/PaymentRequest.java
@@ -1,0 +1,16 @@
+package com.be_notemasterai.payment.dto;
+
+import java.math.BigDecimal;
+
+public record PaymentRequest(
+
+    double amount,
+
+    String impUid,
+
+    String merchantUid
+) {
+  public BigDecimal getAmount() {
+    return new BigDecimal(amount);
+  }
+}

--- a/src/main/java/com/be_notemasterai/payment/dto/PortoneResponse.java
+++ b/src/main/java/com/be_notemasterai/payment/dto/PortoneResponse.java
@@ -1,0 +1,31 @@
+package com.be_notemasterai.payment.dto;
+
+import com.siot.IamportRestClient.response.Payment;
+import java.math.BigDecimal;
+import lombok.Builder;
+
+@Builder
+public record PortoneResponse(
+
+    BigDecimal amount,
+
+    String currency,
+
+    String paymentMethod,
+
+    String impUid,
+
+    String merchantUid
+) {
+
+  public static PortoneResponse of(Payment iamportPayment) {
+
+    return PortoneResponse.builder()
+        .amount(iamportPayment.getAmount())
+        .currency(iamportPayment.getCurrency())
+        .paymentMethod(iamportPayment.getPayMethod())
+        .impUid(iamportPayment.getImpUid())
+        .merchantUid(iamportPayment.getMerchantUid())
+        .build();
+  }
+}

--- a/src/main/java/com/be_notemasterai/payment/dto/PrepareRequest.java
+++ b/src/main/java/com/be_notemasterai/payment/dto/PrepareRequest.java
@@ -1,0 +1,14 @@
+package com.be_notemasterai.payment.dto;
+
+import com.be_notemasterai.subscribe.type.SubscriptionType;
+import java.math.BigDecimal;
+
+public record PrepareRequest(
+    String merchantUid,
+    double amount,
+    SubscriptionType subscriptionType
+) {
+  public BigDecimal getAmount() {
+    return BigDecimal.valueOf(amount);
+  }
+}

--- a/src/main/java/com/be_notemasterai/payment/dto/RefundRequest.java
+++ b/src/main/java/com/be_notemasterai/payment/dto/RefundRequest.java
@@ -1,0 +1,4 @@
+package com.be_notemasterai.payment.dto;
+
+public record RefundRequest(String merchantUid) {
+}

--- a/src/main/java/com/be_notemasterai/payment/entity/Payment.java
+++ b/src/main/java/com/be_notemasterai/payment/entity/Payment.java
@@ -1,0 +1,99 @@
+package com.be_notemasterai.payment.entity;
+
+import static com.be_notemasterai.payment.type.PaymentStatus.REFUNDED;
+import static com.be_notemasterai.payment.type.PaymentStatus.SUCCESS;
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.payment.dto.PortoneResponse;
+import com.be_notemasterai.payment.type.PaymentStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+@Table(name = "payments")
+@EntityListeners(AuditingEntityListener.class)
+public class Payment {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  @JoinColumn(name = "member_id", nullable = false)
+  @ManyToOne(fetch = LAZY)
+  private Member member;
+
+  @Column(nullable = false)
+  private BigDecimal amount;
+
+  @Column(name = "refunded_amount")
+  private BigDecimal refundedAmount;
+
+  @Column(nullable = false)
+  private String currency;
+
+  @Column(name = "payment_method", nullable = false)
+  private String paymentMethod;
+
+  @Column(name = "payment_status", nullable = false)
+  @Enumerated(STRING)
+  private PaymentStatus paymentStatus;
+
+  @Column(name = "imp_uid", nullable = false)
+  private String impUid;
+
+  @Column(name = "merchant_uid", nullable = false)
+  private String merchantUid;
+
+  private LocalDateTime approvedAt;
+
+  private LocalDateTime refundedAt;
+
+  @CreatedDate
+  private LocalDateTime createdAt;
+
+  public static Payment of(Member member, PortoneResponse portoneResponse) {
+
+    return Payment.builder()
+        .member(member)
+        .amount(portoneResponse.amount())
+        .refundedAmount(null)
+        .currency(portoneResponse.currency())
+        .paymentMethod(portoneResponse.paymentMethod())
+        .paymentStatus(SUCCESS)
+        .impUid(portoneResponse.impUid())
+        .merchantUid(portoneResponse.merchantUid())
+        .approvedAt(LocalDateTime.now())
+        .refundedAt(null)
+        .build();
+  }
+
+  public void refund(BigDecimal refundAmount) {
+
+    this.refundedAmount = refundAmount;
+    this.paymentStatus = REFUNDED;
+    this.refundedAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/com/be_notemasterai/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/be_notemasterai/payment/repository/PaymentRepository.java
@@ -1,0 +1,10 @@
+package com.be_notemasterai.payment.repository;
+
+import com.be_notemasterai.payment.entity.Payment;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+  Optional<Payment> findByMerchantUid(String merchantUid);
+}

--- a/src/main/java/com/be_notemasterai/payment/service/PaymentService.java
+++ b/src/main/java/com/be_notemasterai/payment/service/PaymentService.java
@@ -1,0 +1,190 @@
+package com.be_notemasterai.payment.service;
+
+import static com.be_notemasterai.exception.ErrorCode.ALREADY_REFUNDED;
+import static com.be_notemasterai.exception.ErrorCode.FAILED_REFUND_PAYMENT;
+import static com.be_notemasterai.exception.ErrorCode.FAILED_VALID_PAYMENT;
+import static com.be_notemasterai.exception.ErrorCode.INVALID_AMOUNT;
+import static com.be_notemasterai.exception.ErrorCode.NOT_FOUND_PAYMENT;
+import static com.be_notemasterai.exception.ErrorCode.PAYMENT_OWNER_MISMATCH;
+import static com.be_notemasterai.exception.ErrorCode.STATUS_NOT_PAID;
+import static com.be_notemasterai.payment.type.PaymentStatus.REFUNDED;
+import static com.be_notemasterai.subscribe.type.SubscriptionType.MONTH;
+import static com.be_notemasterai.subscribe.type.SubscriptionType.YEAR;
+
+import com.be_notemasterai.exception.CustomException;
+import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.payment.dto.PaymentRequest;
+import com.be_notemasterai.payment.dto.PortoneResponse;
+import com.be_notemasterai.payment.dto.PrepareRequest;
+import com.be_notemasterai.payment.dto.RefundRequest;
+import com.be_notemasterai.payment.entity.Payment;
+import com.be_notemasterai.payment.repository.PaymentRepository;
+import com.be_notemasterai.subscribe.service.SubscribeService;
+import com.be_notemasterai.subscribe.type.SubscriptionType;
+import com.siot.IamportRestClient.IamportClient;
+import com.siot.IamportRestClient.request.CancelData;
+import com.siot.IamportRestClient.request.PrepareData;
+import com.siot.IamportRestClient.response.IamportResponse;
+import com.siot.IamportRestClient.response.Prepare;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class PaymentService {
+
+  private final IamportClient iamportClient;
+
+  private final PaymentRepository paymentRepository;
+
+  private final SubscribeService subscribeService;
+
+  public void preparePayment(PrepareRequest prepareRequest) {
+
+    if (!isValidAmount(prepareRequest.getAmount(), prepareRequest.subscriptionType())) {
+      throw new CustomException(INVALID_AMOUNT);
+    }
+
+    PrepareData prepareData = new PrepareData(prepareRequest.merchantUid(),
+        prepareRequest.getAmount());
+
+    IamportResponse<Prepare> iamportResponse;
+    try {
+      iamportResponse = iamportClient.postPrepare(prepareData);
+
+    } catch (Exception e) {
+      throw new CustomException(FAILED_VALID_PAYMENT);
+    }
+
+    if (iamportResponse.getCode() != 0) {
+      throw new CustomException(FAILED_VALID_PAYMENT);
+    }
+  }
+
+  private boolean isValidAmount(BigDecimal amount, SubscriptionType subscriptionType) {
+    return (subscriptionType == MONTH && amount.compareTo(BigDecimal.valueOf(9900)) == 0) ||
+           (subscriptionType == YEAR && amount.compareTo(BigDecimal.valueOf(99000)) == 0);
+  }
+
+  @Transactional
+  public void verifyAndSavePayment(Member member, PaymentRequest paymentRequest) {
+
+    try {
+      IamportResponse<com.siot.IamportRestClient.response.Payment> response = iamportClient.paymentByImpUid(
+          paymentRequest.impUid());
+      com.siot.IamportRestClient.response.Payment iamportPayment = getPayment(paymentRequest,
+          response);
+
+      PortoneResponse portoneResponse = PortoneResponse.of(iamportPayment);
+
+      Payment payment = Payment.of(member, portoneResponse);
+
+      paymentRepository.save(payment);
+
+      SubscriptionType subscriptionType = determineSubscriptionType(payment.getAmount());
+
+      subscribeService.createSubscription(member, payment, subscriptionType);
+
+    } catch (Exception e) {
+      CancelData cancelData = new CancelData(paymentRequest.impUid(), true, paymentRequest.getAmount());
+      cancelData.setReason("결제 검증 실패로 인한 자동 환불");
+      cancelPayment(cancelData);
+      throw new CustomException(FAILED_VALID_PAYMENT);
+    }
+  }
+
+  private void cancelPayment(CancelData cancelData) {
+
+    try {
+      iamportClient.cancelPaymentByImpUid(cancelData);
+    } catch (Exception e) {
+      throw new CustomException(FAILED_REFUND_PAYMENT);
+    }
+  }
+
+  private static com.siot.IamportRestClient.response.Payment getPayment(
+      PaymentRequest paymentRequest,
+      IamportResponse<com.siot.IamportRestClient.response.Payment> response) {
+    com.siot.IamportRestClient.response.Payment iamportPayment = response.getResponse();
+
+    if (iamportPayment == null) {
+      throw new CustomException(FAILED_VALID_PAYMENT);
+    }
+
+    if (!iamportPayment.getMerchantUid().equals(paymentRequest.merchantUid())) {
+      throw new CustomException(FAILED_VALID_PAYMENT);
+    }
+
+    if (!"paid".equals(iamportPayment.getStatus())) {
+      throw new CustomException(STATUS_NOT_PAID);
+    }
+
+    if (!iamportPayment.getAmount().equals(paymentRequest.getAmount())) {
+      throw new CustomException(INVALID_AMOUNT);
+    }
+
+    return iamportPayment;
+  }
+
+  private SubscriptionType determineSubscriptionType(BigDecimal amount) {
+
+    if (amount.compareTo(BigDecimal.valueOf(9900)) == 0) {
+      return MONTH;
+    } else if (amount.compareTo(BigDecimal.valueOf(99000)) == 0) {
+      return YEAR;
+    } else {
+      throw new CustomException(INVALID_AMOUNT);
+    }
+  }
+
+  @Transactional
+  public void refundPayment(Member member, RefundRequest refundRequest) {
+
+    Payment payment = paymentRepository.findByMerchantUid(refundRequest.merchantUid())
+        .orElseThrow(() -> new CustomException(NOT_FOUND_PAYMENT));
+
+    if (!payment.getMember().getId().equals(member.getId())) {
+      throw new CustomException(PAYMENT_OWNER_MISMATCH);
+    }
+
+    if (payment.getPaymentStatus() == REFUNDED) {
+      throw new CustomException(ALREADY_REFUNDED);
+    }
+
+    long daysUsed = Duration.between(payment.getApprovedAt(), LocalDateTime.now()).toDays();
+    BigDecimal refundAmount = calculateRefundAmount(payment.getAmount(), daysUsed);
+
+    CancelData cancelData = new CancelData(payment.getImpUid(), true, refundAmount);
+    cancelData.setReason("사용자 요청 환불");
+
+    cancelPayment(cancelData);
+
+    payment.refund(refundAmount);
+
+    subscribeService.cancelSubscription(payment);
+  }
+
+  private BigDecimal calculateRefundAmount(BigDecimal amount, long daysUsed) {
+
+    if (daysUsed < 1) {
+      return amount;
+    }
+
+    BigDecimal dailyRate = amount.compareTo(BigDecimal.valueOf(9900)) == 0 ?
+        BigDecimal.valueOf(9900).divide(BigDecimal.valueOf(30), 2, RoundingMode.HALF_UP) :
+        BigDecimal.valueOf(99000).divide(BigDecimal.valueOf(365), 2, RoundingMode.HALF_UP);
+
+    BigDecimal usedAmount = dailyRate.multiply(BigDecimal.valueOf(daysUsed));
+    BigDecimal refundAmount = amount.subtract(usedAmount);
+
+    return refundAmount.max(BigDecimal.ZERO);
+  }
+}

--- a/src/main/java/com/be_notemasterai/payment/type/PaymentStatus.java
+++ b/src/main/java/com/be_notemasterai/payment/type/PaymentStatus.java
@@ -1,0 +1,5 @@
+package com.be_notemasterai.payment.type;
+
+public enum PaymentStatus {
+  SUCCESS, REFUNDED
+}

--- a/src/main/java/com/be_notemasterai/security/jwt/JwtTokenService.java
+++ b/src/main/java/com/be_notemasterai/security/jwt/JwtTokenService.java
@@ -14,7 +14,6 @@ public class JwtTokenService {
 
   private final StringRedisTemplate redisTemplate;
 
-  private static final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 5;
   private static final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 7;
 
   public void setRefreshTokenFromRedis(String providerUuid, String refreshToken) {
@@ -22,22 +21,11 @@ public class JwtTokenService {
     redisTemplate.opsForValue().set(providerUuid, refreshToken, REFRESH_TOKEN_EXPIRATION, SECONDS);
   }
 
-  public void setTokens(HttpServletResponse response, String providerUuid, String accessToken, String refreshToken) {
+  public void setRefreshToken(HttpServletResponse response, String providerUuid, String refreshToken) {
 
     setRefreshTokenFromRedis(providerUuid, refreshToken);
 
-    response.addHeader("Set-Cookie", createAccessCookie(accessToken).toString());
     response.addHeader("Set-Cookie", createRefreshCookie(refreshToken).toString());
-  }
-
-  public ResponseCookie createAccessCookie(String accessToken) {
-
-    return ResponseCookie.from("accessToken", accessToken)
-        .httpOnly(true)
-        .secure(true)
-        .path("/")
-        .maxAge(ACCESS_TOKEN_EXPIRATION)
-        .build();
   }
 
   private ResponseCookie createRefreshCookie(String refreshToken) {

--- a/src/main/java/com/be_notemasterai/security/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/be_notemasterai/security/oauth2/OAuth2SuccessHandler.java
@@ -29,11 +29,9 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
     String providerUuid = principalDetails.getUsername();
 
-    String accessToken = jwtTokenProvider.createAccessToken(providerUuid);
     String refreshToken = jwtTokenProvider.createRefreshToken(providerUuid);
 
-    jwtTokenService.setTokens(response, providerUuid, accessToken, refreshToken);
-
+    jwtTokenService.setRefreshToken(response, providerUuid, refreshToken);
 
     String redirectUri = (principalDetails.member().getNickname() == null)
         ? NICKNAME_SETUP_URI

--- a/src/main/java/com/be_notemasterai/subscribe/entity/Subscribe.java
+++ b/src/main/java/com/be_notemasterai/subscribe/entity/Subscribe.java
@@ -1,11 +1,16 @@
 package com.be_notemasterai.subscribe.entity;
 
+import static com.be_notemasterai.subscribe.type.SubscriptionStatus.ACTIVE;
+import static com.be_notemasterai.subscribe.type.SubscriptionStatus.CANCELLED;
+import static com.be_notemasterai.subscribe.type.SubscriptionStatus.ENDED;
+import static com.be_notemasterai.subscribe.type.SubscriptionType.*;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.payment.entity.Payment;
 import com.be_notemasterai.subscribe.type.SubscriptionStatus;
 import com.be_notemasterai.subscribe.type.SubscriptionType;
 import jakarta.persistence.Column;
@@ -59,4 +64,27 @@ public class Subscribe {
 
   @Column(name = "ended_at")
   private LocalDateTime endedAt;
+
+  public static Subscribe of(Member member, Payment payment, SubscriptionType subscriptionType) {
+
+    LocalDateTime now = LocalDateTime.now();
+
+    return Subscribe.builder()
+        .subscriber(member)
+        .paymentId(payment.getId())
+        .subscriptionType(subscriptionType)
+        .subscriptionStatus(ACTIVE)
+        .startedAt(now)
+        .endedAt(subscriptionType == MONTH ? now.plusMonths(1) : now.plusYears(1))
+        .build();
+  }
+
+  public void cancel() {
+    this.subscriptionStatus = CANCELLED;
+    this.endedAt = LocalDateTime.now();
+  }
+
+  public void expire() {
+    this.subscriptionStatus = ENDED;
+  }
 }

--- a/src/main/java/com/be_notemasterai/subscribe/event/SubscriptionExpiredEvent.java
+++ b/src/main/java/com/be_notemasterai/subscribe/event/SubscriptionExpiredEvent.java
@@ -1,0 +1,4 @@
+package com.be_notemasterai.subscribe.event;
+
+public record SubscriptionExpiredEvent(Long subscribeId) {
+}

--- a/src/main/java/com/be_notemasterai/subscribe/event/listener/SubscriptionEventListener.java
+++ b/src/main/java/com/be_notemasterai/subscribe/event/listener/SubscriptionEventListener.java
@@ -1,0 +1,32 @@
+package com.be_notemasterai.subscribe.event.listener;
+
+import static com.be_notemasterai.exception.ErrorCode.NOT_FOUND_SUBSCRIPTION;
+import static com.be_notemasterai.subscribe.type.SubscriptionStatus.ACTIVE;
+
+import com.be_notemasterai.exception.CustomException;
+import com.be_notemasterai.subscribe.entity.Subscribe;
+import com.be_notemasterai.subscribe.event.SubscriptionExpiredEvent;
+import com.be_notemasterai.subscribe.repository.SubscribeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class SubscriptionEventListener {
+
+  private final SubscribeRepository subscribeRepository;
+
+  @EventListener
+  @Transactional
+  public void handleSubscriptionExpired(SubscriptionExpiredEvent event) {
+
+    Subscribe subscribe = subscribeRepository.findById(event.subscribeId()).orElseThrow(() -> new CustomException(
+        NOT_FOUND_SUBSCRIPTION));
+
+    if (subscribe.getSubscriptionStatus() == ACTIVE) {
+      subscribe.expire();
+    }
+  }
+}

--- a/src/main/java/com/be_notemasterai/subscribe/repository/SubscribeRepository.java
+++ b/src/main/java/com/be_notemasterai/subscribe/repository/SubscribeRepository.java
@@ -2,9 +2,13 @@ package com.be_notemasterai.subscribe.repository;
 
 import com.be_notemasterai.subscribe.entity.Subscribe;
 import com.be_notemasterai.subscribe.type.SubscriptionStatus;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
 
-  boolean existsBySubscriberIdAndSubscriptionStatus(Long memberId, SubscriptionStatus subscriptionStatus);
+  boolean existsBySubscriberIdAndSubscriptionStatus(Long memberId,
+      SubscriptionStatus subscriptionStatus);
+
+  Optional<Subscribe> findByPaymentId(Long id);
 }

--- a/src/main/java/com/be_notemasterai/subscribe/service/SubscribeService.java
+++ b/src/main/java/com/be_notemasterai/subscribe/service/SubscribeService.java
@@ -1,0 +1,57 @@
+package com.be_notemasterai.subscribe.service;
+
+import static com.be_notemasterai.exception.ErrorCode.NOT_FOUND_SUBSCRIPTION;
+
+import com.be_notemasterai.exception.CustomException;
+import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.payment.entity.Payment;
+import com.be_notemasterai.subscribe.entity.Subscribe;
+import com.be_notemasterai.subscribe.event.SubscriptionExpiredEvent;
+import com.be_notemasterai.subscribe.repository.SubscribeRepository;
+import com.be_notemasterai.subscribe.type.SubscriptionType;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SubscribeService {
+
+  private final SubscribeRepository subscribeRepository;
+
+  private final TaskScheduler taskScheduler;
+
+  private final ApplicationEventPublisher eventPublisher;
+
+  @Transactional
+  public void createSubscription(Member member, Payment payment,
+      SubscriptionType subscriptionType) {
+
+    Subscribe subscribe = Subscribe.of(member, payment, subscriptionType);
+    subscribeRepository.save(subscribe);
+
+    scheduleSubscriptionExpiration(subscribe.getId(), subscribe.getEndedAt());
+  }
+
+  private void scheduleSubscriptionExpiration(Long id, LocalDateTime endedAt) {
+
+    Duration delay = Duration.between(LocalDateTime.now(), endedAt);
+    taskScheduler.schedule(() -> eventPublisher.publishEvent(new SubscriptionExpiredEvent(id)),
+        Instant.now().plus(delay));
+  }
+
+  @Transactional
+  public void cancelSubscription(Payment payment) {
+
+    Subscribe subscribe = subscribeRepository.findByPaymentId(payment.getId())
+        .orElseThrow(() -> new CustomException(NOT_FOUND_SUBSCRIPTION));
+
+    subscribe.cancel();
+  }
+}

--- a/src/main/java/com/be_notemasterai/subscribe/type/SubscriptionStatus.java
+++ b/src/main/java/com/be_notemasterai/subscribe/type/SubscriptionStatus.java
@@ -1,5 +1,5 @@
 package com.be_notemasterai.subscribe.type;
 
 public enum SubscriptionStatus {
-  ACTIVE, CANCELLED
+  ACTIVE, CANCELLED, ENDED
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -50,5 +50,8 @@ openai.base-url=${OPEN_AI_BASE_URL}
 naver.cloud.clova.stt.secret=${CLOVA_STT_SECRET}
 naver.cloud.clova.stt.invoke_url=${CLOVA_STT_INVOKE_URL}
 
+portone.api.key=${PORT_ONE_API_KEY}
+portone.api.secret=${PORT_ONE_API_SECRET}
+
 spring.servlet.multipart.max-file-size=2GB
 spring.servlet.multipart.max-request-size=2GB

--- a/src/test/java/com/be_notemasterai/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/be_notemasterai/payment/service/PaymentServiceTest.java
@@ -1,0 +1,86 @@
+package com.be_notemasterai.payment.service;
+
+import static com.be_notemasterai.exception.ErrorCode.INVALID_AMOUNT;
+import static com.be_notemasterai.subscribe.type.SubscriptionType.MONTH;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.be_notemasterai.exception.CustomException;
+import com.be_notemasterai.payment.dto.PrepareRequest;
+import com.be_notemasterai.payment.repository.PaymentRepository;
+import com.be_notemasterai.subscribe.service.SubscribeService;
+import com.siot.IamportRestClient.IamportClient;
+import com.siot.IamportRestClient.response.IamportResponse;
+import com.siot.IamportRestClient.response.Prepare;
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+
+  @Mock
+  private PaymentRepository paymentRepository;
+
+  @Mock
+  private IamportClient iamportClient;
+
+  @Mock
+  private SubscribeService subscribeService;
+
+  @InjectMocks
+  private PaymentService paymentService;
+
+  private final String merchantUid = "order_123456";
+  private final String impUid = "imp_123456";
+  private final double amount = 9900;
+
+  private BigDecimal getAmount() {
+    return BigDecimal.valueOf(amount);
+  }
+
+  private void setField(Object target, String fieldName, Object value) throws Exception {
+    Field field = target.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  @Test
+  @DisplayName("사전 결제 검증이 성공한다")
+  void prepare_payment_success() throws Exception {
+    // given
+    PrepareRequest prepareRequest = new PrepareRequest(merchantUid, amount, MONTH);
+    IamportResponse<Prepare> response = new IamportResponse<>();
+    Prepare prepare = new Prepare();
+
+    setField(response, "code", 0);
+
+    setField(response, "response", prepare);
+
+    when(iamportClient.postPrepare(any())).thenReturn(response);
+    // when
+    // then
+    assertDoesNotThrow(() -> paymentService.preparePayment(prepareRequest));
+  }
+
+  @Test
+  @DisplayName("결제 금액이 일치하지 않으면 예외가 발생한다")
+  void prepare_payment_failure_invalid_amount() {
+    // given
+    PrepareRequest prepareRequest = new PrepareRequest(merchantUid, 10000.0, MONTH);
+
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> paymentService.preparePayment(prepareRequest));
+    // then
+    assertEquals(e.getErrorCode(), INVALID_AMOUNT);
+  }
+}

--- a/src/test/java/com/be_notemasterai/subscribe/service/SubscribeServiceTest.java
+++ b/src/test/java/com/be_notemasterai/subscribe/service/SubscribeServiceTest.java
@@ -1,0 +1,85 @@
+package com.be_notemasterai.subscribe.service;
+
+import static com.be_notemasterai.exception.ErrorCode.NOT_FOUND_SUBSCRIPTION;
+import static com.be_notemasterai.subscribe.type.SubscriptionStatus.ACTIVE;
+import static com.be_notemasterai.subscribe.type.SubscriptionType.MONTH;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.be_notemasterai.exception.CustomException;
+import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.payment.entity.Payment;
+import com.be_notemasterai.subscribe.entity.Subscribe;
+import com.be_notemasterai.subscribe.repository.SubscribeRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.TaskScheduler;
+
+@ExtendWith(MockitoExtension.class)
+class SubscribeServiceTest {
+
+  @Mock
+  private SubscribeRepository subscribeRepository;
+
+  @Mock
+  private TaskScheduler taskScheduler;
+
+  @Mock
+  private ApplicationEventPublisher applicationEventPublisher;
+
+  @InjectMocks
+  private SubscribeService subscribeService;
+
+  @Test
+  @DisplayName("구독 생성에 성공한다")
+  void create_subscription_success() {
+    // given
+    Member member = mock(Member.class);
+    Payment payment = mock(Payment.class);
+    // when
+    subscribeService.createSubscription(member, payment, MONTH);
+    // then
+    verify(subscribeRepository).save(any());
+  }
+
+  @Test
+  @DisplayName("구독 취소에 성공한다")
+  void cancel_subscription_success() {
+    // given
+    Payment payment = Payment.builder().id(1L).build();
+    Subscribe subscribe = Subscribe.builder().paymentId(payment.getId()).subscriptionStatus(ACTIVE)
+        .build();
+
+    when(subscribeRepository.findByPaymentId(subscribe.getPaymentId())).thenReturn(
+        Optional.of(subscribe));
+    // when
+    // then
+    assertDoesNotThrow(() -> subscribeService.cancelSubscription(payment));
+  }
+
+  @Test
+  @DisplayName("구독 내역이 없으면 취소에 실패한다")
+  void cancel_subscription_failure_not_found_subscription() {
+    // given
+    Payment payment = Payment.builder().id(1L).build();
+
+    when(subscribeRepository.findByPaymentId(anyLong())).thenReturn(Optional.empty());
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> subscribeService.cancelSubscription(payment));
+    // then
+    assertEquals(e.getErrorCode(), NOT_FOUND_SUBSCRIPTION);
+  }
+}


### PR DESCRIPTION
## 🛠️ 작업 내용 (What)
- 결제 (PortOne) 관련 구현
- Access Token 쿠키 저장 -> 응답 바디로 반환 후 클라이언트에서 세션 저장
## 📌 작업 이유 (Why)
- 결제 관련 구현
- 토큰 저장 위치 변경
## ✨ 변경 사항 (Changes)
- Port One API 연동을 위한 key, secret 설정
- 구독 만료를 위한 TaskScheduler 설정
- 결제 전 금액 변조 방지를 위한 사전 검증 구현
  - 설정한 구독 타입과 금액이 다르면 결제 진행하지 않음
  - Merchant Uid 값이 Iamport 서버와 비교하여 유효한 값이며, 중복 내역이 없는지 확인
- 사후 검증을 통해 실제로 결제가 완료되었는지, 결제된 내역이 클라이언트의 사후 검증과 일치하는 지 확인
  - 해당 검증을 통과하면 DB에 결제내역과 구독 정보를 저장
  - 해당 검증을 통과하지 못하면 자동 환불 구현
- 구독 해지 구현
  - 결제한 날짜 기준으로 실제 사용한 날짜를 제외한 나머지 금액 환불
  - 하루만에 환불하는 경우엔 전체 금액 환불
## ✅ 테스트 (Tests)
- [ ] 사전 결제 검증이 성공한다
- [ ] 결제 금액이 일치하지 않으면 예외가 발생한다
- [ ] 구독 생성에 성공한다
- [ ] 구독 취소에 성공한다
- [ ] 구독 내역이 없으면 취소에 실패한다