### PR TITLE
✨feat: Note 관련 구현

### DIFF
--- a/src/main/java/com/be_notemasterai/config/JacksonConfig.java
+++ b/src/main/java/com/be_notemasterai/config/JacksonConfig.java
@@ -1,0 +1,23 @@
+package com.be_notemasterai.config;
+
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import java.time.format.DateTimeFormatter;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+  private static final String DATETIME_FORMAT = "yyyy-MM-dd HH:mm";
+  private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATETIME_FORMAT);
+
+  @Bean
+  public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer() {
+    return builder -> builder
+        .serializers(new LocalDateTimeSerializer(formatter))
+        .featuresToDisable(WRITE_DATES_AS_TIMESTAMPS);
+  }
+}

--- a/src/main/java/com/be_notemasterai/exception/ErrorCode.java
+++ b/src/main/java/com/be_notemasterai/exception/ErrorCode.java
@@ -26,10 +26,12 @@ public enum ErrorCode {
   // 403 FORBIDDEN
   NOT_SUBSCRIBER(FORBIDDEN, "구독자만 접근 가능합니다."),
   PAYMENT_OWNER_MISMATCH(FORBIDDEN, "결제정보가 일치하지 않습니다."),
+  NOTE_OWNER_MISMATCH(FORBIDDEN, "노트 작성자만 접근 가능합니다."),
   // 404 NOT FOUND
   NOT_FOUND_MEMBER(NOT_FOUND, "회원 정보가 없습니다."),
   NOT_FOUND_PAYMENT(NOT_FOUND, "결제 정보가 없습니다."),
   NOT_FOUND_SUBSCRIPTION(NOT_FOUND, "구독 내역을 확인할 수 없습니다."),
+  NOT_FOUND_NOTE(NOT_FOUND, "노트를 찾을 수 없습니다."),
   // 408 REQUEST TIMEOUT
 
   // 409 CONFLICT

--- a/src/main/java/com/be_notemasterai/note/controller/NoteController.java
+++ b/src/main/java/com/be_notemasterai/note/controller/NoteController.java
@@ -1,0 +1,60 @@
+package com.be_notemasterai.note.controller;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.note.dto.NoteListResponse;
+import com.be_notemasterai.note.dto.NoteResponse;
+import com.be_notemasterai.note.dto.NoteUpdateRequest;
+import com.be_notemasterai.note.service.NoteService;
+import com.be_notemasterai.security.resolver.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notes")
+public class NoteController {
+
+  private final NoteService noteService;
+
+  @GetMapping
+  public ResponseEntity<Page<NoteListResponse>> getNotes(
+      @CurrentMember Member owner,
+      @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
+
+    return ResponseEntity.ok(noteService.getNotes(owner, pageable));
+  }
+
+  @GetMapping("/{noteId}")
+  public ResponseEntity<NoteResponse> getNote(@CurrentMember Member owner,
+      @PathVariable Long noteId) {
+
+    return ResponseEntity.ok(noteService.getNote(owner, noteId));
+  }
+
+  @PostMapping("/{noteId}")
+  public ResponseEntity<NoteResponse> updateNote(@CurrentMember Member owner,
+      @PathVariable Long noteId, @RequestBody NoteUpdateRequest noteUpdateRequest) {
+
+    return ResponseEntity.ok(noteService.updateNote(owner, noteId, noteUpdateRequest));
+  }
+
+  @DeleteMapping("/{noteId}")
+  public ResponseEntity<Void> deleteNote(@CurrentMember Member owner, @PathVariable Long noteId) {
+
+    noteService.deleteNote(owner, noteId);
+
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/be_notemasterai/note/dto/NoteListResponse.java
+++ b/src/main/java/com/be_notemasterai/note/dto/NoteListResponse.java
@@ -1,0 +1,27 @@
+package com.be_notemasterai.note.dto;
+
+import com.be_notemasterai.note.entity.Note;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record NoteListResponse(
+
+    Long noteId,
+    Long ownerId,
+    String ownerNickname,
+    String title,
+    LocalDateTime createdAt
+) {
+
+  public static NoteListResponse fromEntity(Note note) {
+
+    return NoteListResponse.builder()
+        .noteId(note.getId())
+        .ownerId(note.getOwner().getId())
+        .ownerNickname(note.getOwner().getNickname())
+        .title(note.getTitle())
+        .createdAt(note.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/be_notemasterai/note/dto/NoteResponse.java
+++ b/src/main/java/com/be_notemasterai/note/dto/NoteResponse.java
@@ -1,0 +1,27 @@
+package com.be_notemasterai.note.dto;
+
+import com.be_notemasterai.note.entity.Note;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record NoteResponse(
+
+    Long noteId,
+    String title,
+    String originalText,
+    String summary,
+    LocalDateTime createdAt
+) {
+
+  public static NoteResponse fromEntity(Note note) {
+
+    return NoteResponse.builder()
+        .noteId(note.getId())
+        .title(note.getTitle())
+        .originalText(note.getOriginalText())
+        .summary(note.getSummary())
+        .createdAt(note.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/be_notemasterai/note/dto/NoteUpdateRequest.java
+++ b/src/main/java/com/be_notemasterai/note/dto/NoteUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.be_notemasterai.note.dto;
+
+public record NoteUpdateRequest(String title, String summary) {
+}

--- a/src/main/java/com/be_notemasterai/note/entity/Note.java
+++ b/src/main/java/com/be_notemasterai/note/entity/Note.java
@@ -5,6 +5,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.note.dto.NoteUpdateRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -51,9 +52,6 @@ public class Note {
   @Column(name = "created_at")
   private LocalDateTime createdAt;
 
-  @Column(name = "deleted_at")
-  private LocalDateTime deletedAt;
-
   public static Note of(Member owner, String title, String originalText, String summary) {
 
     return Note.builder()
@@ -62,5 +60,11 @@ public class Note {
         .originalText(originalText)
         .summary(summary)
         .build();
+  }
+
+  public void updateNote(NoteUpdateRequest noteUpdateRequest) {
+
+    title = noteUpdateRequest.title();
+    summary = noteUpdateRequest.summary();
   }
 }

--- a/src/main/java/com/be_notemasterai/note/repository/NoteRepository.java
+++ b/src/main/java/com/be_notemasterai/note/repository/NoteRepository.java
@@ -1,8 +1,12 @@
 package com.be_notemasterai.note.repository;
 
+import com.be_notemasterai.member.entity.Member;
 import com.be_notemasterai.note.entity.Note;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NoteRepository extends JpaRepository<Note, Long> {
 
+  Page<Note> findByOwner(Member member, Pageable pageable);
 }

--- a/src/main/java/com/be_notemasterai/note/service/NoteService.java
+++ b/src/main/java/com/be_notemasterai/note/service/NoteService.java
@@ -1,9 +1,18 @@
 package com.be_notemasterai.note.service;
 
+import static com.be_notemasterai.exception.ErrorCode.NOTE_OWNER_MISMATCH;
+import static com.be_notemasterai.exception.ErrorCode.NOT_FOUND_NOTE;
+
+import com.be_notemasterai.exception.CustomException;
 import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.note.dto.NoteListResponse;
+import com.be_notemasterai.note.dto.NoteResponse;
+import com.be_notemasterai.note.dto.NoteUpdateRequest;
 import com.be_notemasterai.note.entity.Note;
 import com.be_notemasterai.note.repository.NoteRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,5 +27,49 @@ public class NoteService {
   public void createNote(Member owner, String title, String originalText, String summary) {
 
     noteRepository.save(Note.of(owner, title, originalText, summary));
+  }
+
+  public Page<NoteListResponse> getNotes(Member owner, Pageable pageable) {
+
+    Page<Note> notes = noteRepository.findByOwner(owner, pageable);
+
+    return notes.map(NoteListResponse::fromEntity);
+  }
+
+  public NoteResponse getNote(Member owner, Long noteId) {
+
+    Note note = findNoteAndOwner(owner, noteId);
+
+    return NoteResponse.fromEntity(note);
+  }
+
+  @Transactional
+  public NoteResponse updateNote(Member owner, Long noteId, NoteUpdateRequest noteUpdateRequest) {
+
+    Note note = findNoteAndOwner(owner, noteId);
+
+    note.updateNote(noteUpdateRequest);
+
+    return NoteResponse.fromEntity(note);
+  }
+
+  @Transactional
+  public void deleteNote(Member owner, Long noteId) {
+
+    Note note = findNoteAndOwner(owner, noteId);
+
+    noteRepository.delete(note);
+  }
+
+  private Note findNoteAndOwner(Member owner, Long noteId) {
+
+    Note note = noteRepository.findById(noteId)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_NOTE));
+
+    if (!owner.getId().equals(note.getOwner().getId())) {
+      throw new CustomException(NOTE_OWNER_MISMATCH);
+    }
+
+    return note;
   }
 }

--- a/src/test/java/com/be_notemasterai/note/service/NoteServiceTest.java
+++ b/src/test/java/com/be_notemasterai/note/service/NoteServiceTest.java
@@ -1,11 +1,24 @@
 package com.be_notemasterai.note.service;
 
+import static com.be_notemasterai.exception.ErrorCode.NOTE_OWNER_MISMATCH;
+import static com.be_notemasterai.exception.ErrorCode.NOT_FOUND_NOTE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
+import com.be_notemasterai.exception.CustomException;
 import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.note.dto.NoteListResponse;
+import com.be_notemasterai.note.dto.NoteResponse;
+import com.be_notemasterai.note.dto.NoteUpdateRequest;
 import com.be_notemasterai.note.entity.Note;
 import com.be_notemasterai.note.repository.NoteRepository;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,6 +26,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class NoteServiceTest {
@@ -28,6 +45,7 @@ class NoteServiceTest {
   @BeforeEach
   void setUp() {
     member = Member.builder()
+        .id(1L)
         .provider("google")
         .providerUuid("providerUuid")
         .name("이름")
@@ -38,11 +56,98 @@ class NoteServiceTest {
 
   @Test
   @DisplayName("노트가 성공적으로 생성된다")
-  void createNote_success() {
+  void create_note_success() {
     // given
     // when
     noteService.createNote(member, "제목", "원본", "요약");
     // then
     verify(noteRepository).save(any(Note.class));
+  }
+
+  @Test
+  @DisplayName("노트 목록을 성공적으로 반환한다")
+  void get_notes_success() {
+    // given
+    Pageable pageable = PageRequest.of(0, 10, DESC, "createdAt");
+    List<Note> noteList = List.of(
+        Note.of(member, "제목1", "원본1", "요약1"),
+        Note.of(member, "제목2", "원본2", "요약2"));
+
+    Page<Note> page = new PageImpl<>(noteList, pageable, noteList.size());
+
+    when(noteRepository.findByOwner(member, pageable)).thenReturn(page);
+    // when
+    Page<NoteListResponse> result = noteService.getNotes(member, pageable);
+    // then
+    assertEquals(2, result.getTotalElements());
+    assertEquals("제목2", result.getContent().get(1).title());
+  }
+
+  @Test
+  @DisplayName("노트 상세를 성공적으로 반환한다")
+  void get_note_success() {
+    // given
+    Note note = Note.of(member, "제목", "원본", "요약");
+    when(noteRepository.findById(1L)).thenReturn(Optional.of(note));
+    // when
+    NoteResponse result = noteService.getNote(member, 1L);
+    // then
+    assertNotNull(result);
+    assertEquals("제목", result.title());
+    assertEquals("요약", result.summary());
+  }
+
+  @Test
+  @DisplayName("노트의 주인이 아니면 예외가 발생한다")
+  void get_note_failure_owner_mismatch() {
+    // given
+    Member anotherMember = Member.builder().id(2L).providerUuid("anotherProviderUuid").build();
+    Note note = Note.of(member, "제목", "원본", "요약");
+
+    when(noteRepository.findById(1L)).thenReturn(Optional.of(note));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> noteService.getNote(anotherMember, 1L));
+    // then
+    assertEquals(e.getErrorCode(), NOTE_OWNER_MISMATCH);
+  }
+
+  @Test
+  @DisplayName("노트가 존재하지 않으면 예외가 발생한다")
+  void get_note_failure_not_found() {
+    // given
+    when(noteRepository.findById(1L)).thenReturn(Optional.empty());
+    // when
+    CustomException e = assertThrows(CustomException.class, () -> noteService.getNote(member, 1L));
+    // then
+    assertEquals(e.getErrorCode(), NOT_FOUND_NOTE);
+  }
+
+  @Test
+  @DisplayName("노트 수정에 성공한다")
+  void update_note_success() {
+    // given
+    Note note = Note.of(member, "제목", "원본", "요약");
+    NoteUpdateRequest noteUpdateRequest = new NoteUpdateRequest("수정 제목", "수정 요약");
+
+    when(noteRepository.findById(1L)).thenReturn(Optional.of(note));
+    // when
+    NoteResponse result = noteService.updateNote(member, 1L, noteUpdateRequest);
+    // then
+    assertEquals("수정 제목", result.title());
+    assertEquals("수정 요약", result.summary());
+  }
+
+  @Test
+  @DisplayName("노트 삭제에 성공한다")
+  void delete_note_success() {
+    // given
+    Note note = Note.of(member, "제목", "원본", "요약");
+
+    when(noteRepository.findById(1L)).thenReturn(Optional.of(note));
+    // when
+    noteService.deleteNote(member, 1L);
+    // then
+    verify(noteRepository).delete(note);
   }
 }


### PR DESCRIPTION
## 🛠️ 작업 내용 (What)
- Note 관련 구현
## 📌 작업 이유 (Why)
- 노트 CRUD 구현
## ✨ 변경 사항 (Changes)
- 생성된 노트 목록 조회
  - 페이징 처리 하여 0 페이지 부터 조회 가능
  - 로그인 한 회원만 접근 가능
- 노트 상세 조회 구현
  - 노트의 제목, 요약본, 원본, 생성일 등 확인 가능
- 노트의 제목과 요약본은 수정 가능
- 노트 삭제 가능
- 날짜 포맷팅 yyyy-MM-dd HH:mm 으로 맞추기 위한 전역 설정 클래스 추가
## ✅ 테스트 (Tests)
- [ ] 노트 목록을 성공적으로 반환한다
- [ ] 노트 상세를 성공적으로 반환한다
- [ ] 노트의 주인이 아니면 예외가 발생한다
- [ ] 노트가 존재하지 않으면 예외가 발생한다
- [ ] 노트 수정에 성공한다
- [ ] 노트 삭제에 성공한다