### PR TITLE
✨feat: Group 관련 구현

### DIFF
--- a/src/main/java/com/be_notemasterai/exception/ErrorCode.java
+++ b/src/main/java/com/be_notemasterai/exception/ErrorCode.java
@@ -20,6 +20,13 @@ public enum ErrorCode {
   EMPTY_SOUND_FILE(BAD_REQUEST, "음성파일이 업로드 되지 않았습니다."),
   STATUS_NOT_PAID(BAD_REQUEST, "결제 상태가 paid 가 아닙니다."),
   INVALID_AMOUNT(BAD_REQUEST, "결제 금액이 일치하지 않습니다."),
+  INVALID_GROUP_NOTE(BAD_REQUEST, "그룹에 속한 노트가 아닙니다."),
+  INVALID_GROUP_MEMBER(BAD_REQUEST, "그룹에 속한 회원이 아닙니다."),
+  SELF_TAG_SEARCH_NOT_ALLOWED(BAD_REQUEST, "자기 자신은 태그로 조회할 수 없습니다."),
+  SELF_INVITE_NOT_ALLOWED(BAD_REQUEST, "자기 자신은 그룹에 초대할 수 없습니다."),
+  EXIST_GROUP_MEMBER(BAD_REQUEST, "그룹에 회원이 존재하는 경우 삭제할 수 없습니다"),
+  CANNOT_LEAVE_GROUP_AS_OWNER(BAD_REQUEST, "그룹장은 그룹을 떠날 수 없습니다."),
+  CANNOT_REMOVE_GROUP_OWNER(BAD_REQUEST, "그룹장은 그룹에서 제거할 수 없습니다."),
   // 401 UNAUTHORIZED
   INVALID_TOKEN(UNAUTHORIZED, "유효하지 않은 토큰입니다."),
   INVALID_REFRESH_TOKEN(UNAUTHORIZED, "리프레쉬 토큰이 유효하지 않습니다."),
@@ -27,16 +34,21 @@ public enum ErrorCode {
   NOT_SUBSCRIBER(FORBIDDEN, "구독자만 접근 가능합니다."),
   PAYMENT_OWNER_MISMATCH(FORBIDDEN, "결제정보가 일치하지 않습니다."),
   NOTE_OWNER_MISMATCH(FORBIDDEN, "노트 작성자만 접근 가능합니다."),
+  NOT_GROUP_OWNER(FORBIDDEN, "그룹 생성자만 접근 가능합니다."),
   // 404 NOT FOUND
   NOT_FOUND_MEMBER(NOT_FOUND, "회원 정보가 없습니다."),
   NOT_FOUND_PAYMENT(NOT_FOUND, "결제 정보가 없습니다."),
   NOT_FOUND_SUBSCRIPTION(NOT_FOUND, "구독 내역을 확인할 수 없습니다."),
   NOT_FOUND_NOTE(NOT_FOUND, "노트를 찾을 수 없습니다."),
+  NOT_FOUND_GROUP(NOT_FOUND, "그룹을 찾을 수 없습니다."),
   // 408 REQUEST TIMEOUT
 
   // 409 CONFLICT
   EXISTS_NICKNAME(CONFLICT, "이미 존재하는 닉네임 입니다."),
   ALREADY_REFUNDED(CONFLICT, "이미 환불되었습니다."),
+  ALREADY_SET_GROUP_NOTE(CONFLICT, "이미 그룹에 속한 노트입니다."),
+  ALREADY_SET_GROUP_NULL(CONFLICT, "이미 그룹에서 제거되었습니다."),
+  ALREADY_SET_GROUP_MEMBER(CONFLICT, "이미 그룹에 속한 회원입니다."),
   // 500 INTERNAL SERVER ERROR
   FAILED_VALID_PAYMENT(HttpStatus.INTERNAL_SERVER_ERROR, "결제 검증에 실패하였습니다."),
   FAILED_REFUND_PAYMENT(HttpStatus.INTERNAL_SERVER_ERROR, "결제 환불에 실패하였습니다."),

--- a/src/main/java/com/be_notemasterai/group/controller/GroupController.java
+++ b/src/main/java/com/be_notemasterai/group/controller/GroupController.java
@@ -1,0 +1,131 @@
+package com.be_notemasterai.group.controller;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+import com.be_notemasterai.group.dto.GroupListResponse;
+import com.be_notemasterai.group.dto.GroupMemberListResponse;
+import com.be_notemasterai.group.dto.GroupRequest;
+import com.be_notemasterai.group.dto.GroupResponse;
+import com.be_notemasterai.group.dto.GroupUpdateRequest;
+import com.be_notemasterai.group.service.GroupService;
+import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.note.dto.NoteListResponse;
+import com.be_notemasterai.security.resolver.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/groups")
+public class GroupController {
+
+  private final GroupService groupService;
+
+  @PostMapping
+  public ResponseEntity<GroupResponse> createGroup(@CurrentMember Member member,
+      @RequestBody GroupRequest groupRequest) {
+
+    return ResponseEntity.ok(groupService.createGroup(member, groupRequest));
+  }
+
+  @PutMapping("/{groupId}/notes/{noteId}")
+  public ResponseEntity<Page<NoteListResponse>> addNoteToGroup(@CurrentMember Member member,
+      @PathVariable Long groupId,
+      @PathVariable Long noteId,
+      @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
+
+    return ResponseEntity.ok(groupService.addNoteToGroup(member, groupId, noteId, pageable));
+  }
+
+  @DeleteMapping("/{groupId}/notes/{noteId}")
+  public ResponseEntity<Page<NoteListResponse>> removeNoteFromGroup(@CurrentMember Member member,
+      @PathVariable Long groupId, @PathVariable Long noteId,
+      @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
+
+    return ResponseEntity.ok(groupService.removeNoteFromGroup(member, groupId, noteId, pageable));
+  }
+
+  @GetMapping
+  public ResponseEntity<Page<GroupListResponse>> getGroups(@CurrentMember Member member,
+      @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
+
+    return ResponseEntity.ok(groupService.getGroups(member, pageable));
+  }
+
+  @GetMapping("/{groupId}")
+  public ResponseEntity<GroupResponse> getGroup(@CurrentMember Member member,
+      @PathVariable Long groupId) {
+
+    return ResponseEntity.ok(groupService.getGroup(member, groupId));
+  }
+
+  @DeleteMapping("/{groupId}")
+  public ResponseEntity<Void> deleteGroup(@CurrentMember Member member,
+      @PathVariable Long groupId) {
+
+    groupService.deleteGroup(member, groupId);
+
+    return ResponseEntity.ok().build();
+  }
+
+  @PutMapping("/{groupId}")
+  public ResponseEntity<GroupResponse> updateGroup(@CurrentMember Member member,
+      @PathVariable Long groupId,
+      @RequestBody GroupUpdateRequest groupUpdateRequest) {
+
+    return ResponseEntity.ok(groupService.updateGroup(member, groupId, groupUpdateRequest));
+  }
+
+  @PostMapping("/{groupId}/members/{memberId}")
+  public ResponseEntity<Void> inviteMember(@CurrentMember Member owner, @PathVariable Long groupId,
+      @PathVariable Long memberId) {
+
+    groupService.inviteMember(owner, groupId, memberId);
+
+    return ResponseEntity.ok().build();
+  }
+
+  @DeleteMapping("/{groupId}/leave")
+  public ResponseEntity<Void> leaveGroup(@CurrentMember Member member, @PathVariable Long groupId) {
+
+    groupService.leaveGroup(member, groupId);
+
+    return ResponseEntity.ok().build();
+  }
+
+  @GetMapping("/{groupId}/notes")
+  public ResponseEntity<Page<NoteListResponse>> getNotesInGroup(@CurrentMember Member member,
+      @PathVariable Long groupId,
+      @PageableDefault(sort = "cratedAt", direction = DESC) Pageable pageable) {
+
+    return ResponseEntity.ok(groupService.getNotesInGroup(member, groupId, pageable));
+  }
+
+  @DeleteMapping("/{groupId}/members/{memberId}")
+  public ResponseEntity<Void> removeMemberFromGroup(@CurrentMember Member member,
+      @PathVariable Long groupId, @PathVariable Long memberId) {
+
+    groupService.removeMemberFromGroup(member, groupId, memberId);
+
+    return ResponseEntity.ok().build();
+  }
+
+  @GetMapping("/{groupId}/members")
+  public ResponseEntity<Page<GroupMemberListResponse>> getGroupMembers(@CurrentMember Member member,
+      @PathVariable Long groupId,
+      @PageableDefault(sort = "groupRole", direction = DESC) Pageable pageable) {
+
+    return ResponseEntity.ok(groupService.getGroupMembers(member, groupId, pageable));
+  }
+}

--- a/src/main/java/com/be_notemasterai/group/dto/GroupListResponse.java
+++ b/src/main/java/com/be_notemasterai/group/dto/GroupListResponse.java
@@ -1,0 +1,22 @@
+package com.be_notemasterai.group.dto;
+
+import com.be_notemasterai.group.entity.Group;
+import lombok.Builder;
+
+@Builder
+public record GroupListResponse(
+
+    Long groupId,
+    String groupName,
+    Long memberCount
+) {
+
+  public static GroupListResponse fromEntity(Group group, long memberCount) {
+
+    return GroupListResponse.builder()
+        .groupId(group.getId())
+        .groupName(group.getGroupName())
+        .memberCount(memberCount)
+        .build();
+  }
+}

--- a/src/main/java/com/be_notemasterai/group/dto/GroupMemberListResponse.java
+++ b/src/main/java/com/be_notemasterai/group/dto/GroupMemberListResponse.java
@@ -1,0 +1,25 @@
+package com.be_notemasterai.group.dto;
+
+import com.be_notemasterai.group.entity.GroupMember;
+import com.be_notemasterai.group.type.GroupRole;
+import lombok.Builder;
+
+@Builder
+public record GroupMemberListResponse(
+
+    Long memberId,
+    String nickname,
+    String profileImageUrl,
+    GroupRole groupRole
+) {
+
+  public static GroupMemberListResponse fromEntity(GroupMember groupMember) {
+
+    return GroupMemberListResponse.builder()
+        .memberId(groupMember.getMember().getId())
+        .nickname(groupMember.getMember().getNickname())
+        .profileImageUrl(groupMember.getMember().getProfileImageUrl())
+        .groupRole(groupMember.getGroupRole())
+        .build();
+  }
+}

--- a/src/main/java/com/be_notemasterai/group/dto/GroupRequest.java
+++ b/src/main/java/com/be_notemasterai/group/dto/GroupRequest.java
@@ -1,0 +1,7 @@
+package com.be_notemasterai.group.dto;
+
+public record GroupRequest(
+    String groupName,
+    String groupDescription
+) {
+}

--- a/src/main/java/com/be_notemasterai/group/dto/GroupResponse.java
+++ b/src/main/java/com/be_notemasterai/group/dto/GroupResponse.java
@@ -1,0 +1,22 @@
+package com.be_notemasterai.group.dto;
+
+import com.be_notemasterai.group.entity.Group;
+import lombok.Builder;
+
+@Builder
+public record GroupResponse(
+
+    Long groupId,
+    String groupName,
+    String groupDescription
+) {
+
+  public static GroupResponse fromEntity(Group group) {
+
+    return GroupResponse.builder()
+        .groupId(group.getId())
+        .groupName(group.getGroupName())
+        .groupDescription(group.getGroupDescription())
+        .build();
+  }
+}

--- a/src/main/java/com/be_notemasterai/group/dto/GroupUpdateRequest.java
+++ b/src/main/java/com/be_notemasterai/group/dto/GroupUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.be_notemasterai.group.dto;
+
+public record GroupUpdateRequest(String groupName, String groupDescription) {
+}

--- a/src/main/java/com/be_notemasterai/group/entity/Group.java
+++ b/src/main/java/com/be_notemasterai/group/entity/Group.java
@@ -1,0 +1,58 @@
+package com.be_notemasterai.group.entity;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.be_notemasterai.group.dto.GroupRequest;
+import com.be_notemasterai.group.dto.GroupUpdateRequest;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+@Table(name = "groups")
+@EntityListeners(AuditingEntityListener.class)
+@Builder
+public class Group {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  @Column(name = "group_name", nullable = false)
+  private String groupName;
+
+  @Column(name = "group_description")
+  private String groupDescription;
+
+  @CreatedDate
+  @Column(name = "created_at")
+  private LocalDateTime createdAt;
+
+  public static Group of(GroupRequest groupRequest) {
+
+    return Group.builder()
+        .groupName(groupRequest.groupName())
+        .groupDescription(groupRequest.groupDescription())
+        .build();
+  }
+
+  public void update(GroupUpdateRequest groupUpdateRequest) {
+
+    groupName = groupUpdateRequest.groupName();
+    groupDescription = groupUpdateRequest.groupDescription();
+  }
+}

--- a/src/main/java/com/be_notemasterai/group/entity/GroupMember.java
+++ b/src/main/java/com/be_notemasterai/group/entity/GroupMember.java
@@ -1,0 +1,58 @@
+package com.be_notemasterai.group.entity;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+import static org.hibernate.annotations.OnDeleteAction.CASCADE;
+
+import com.be_notemasterai.group.type.GroupRole;
+import com.be_notemasterai.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+@Getter
+@Table(name = "group_member")
+@Builder
+public class GroupMember {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "group_id", nullable = false)
+  @OnDelete(action = CASCADE)
+  private Group group;
+
+  @Enumerated(STRING)
+  @Column(name = "group_role", nullable = false)
+  private GroupRole groupRole;
+
+  public static GroupMember of(Member member, Group group, GroupRole groupRole) {
+
+    return GroupMember.builder()
+        .member(member)
+        .group(group)
+        .groupRole(groupRole)
+        .build();
+  }
+}

--- a/src/main/java/com/be_notemasterai/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/be_notemasterai/group/repository/GroupMemberRepository.java
@@ -1,0 +1,20 @@
+package com.be_notemasterai.group.repository;
+
+import com.be_notemasterai.group.entity.Group;
+import com.be_notemasterai.group.entity.GroupMember;
+import com.be_notemasterai.member.entity.Member;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+
+  long countByGroup(Group group);
+
+  Optional<GroupMember> findByMemberAndGroup(Member member, Group group);
+
+  boolean existsByMemberAndGroup(Member member, Group group);
+
+  Page<GroupMember> findByGroup(Group group, Pageable pageable);
+}

--- a/src/main/java/com/be_notemasterai/group/repository/GroupRepository.java
+++ b/src/main/java/com/be_notemasterai/group/repository/GroupRepository.java
@@ -1,0 +1,15 @@
+package com.be_notemasterai.group.repository;
+
+import com.be_notemasterai.group.entity.Group;
+import com.be_notemasterai.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+
+  @Query("SELECT g FROM Group g JOIN GroupMember gm ON g.id = gm.group.id WHERE gm.member = :member")
+  Page<Group> findGroupsByMember(@Param("member") Member member, Pageable pageable);
+}

--- a/src/main/java/com/be_notemasterai/group/service/GroupService.java
+++ b/src/main/java/com/be_notemasterai/group/service/GroupService.java
@@ -1,0 +1,275 @@
+package com.be_notemasterai.group.service;
+
+import static com.be_notemasterai.exception.ErrorCode.ALREADY_SET_GROUP_MEMBER;
+import static com.be_notemasterai.exception.ErrorCode.ALREADY_SET_GROUP_NOTE;
+import static com.be_notemasterai.exception.ErrorCode.ALREADY_SET_GROUP_NULL;
+import static com.be_notemasterai.exception.ErrorCode.CANNOT_LEAVE_GROUP_AS_OWNER;
+import static com.be_notemasterai.exception.ErrorCode.CANNOT_REMOVE_GROUP_OWNER;
+import static com.be_notemasterai.exception.ErrorCode.EXIST_GROUP_MEMBER;
+import static com.be_notemasterai.exception.ErrorCode.INVALID_GROUP_MEMBER;
+import static com.be_notemasterai.exception.ErrorCode.INVALID_GROUP_NOTE;
+import static com.be_notemasterai.exception.ErrorCode.NOT_FOUND_GROUP;
+import static com.be_notemasterai.exception.ErrorCode.NOT_FOUND_MEMBER;
+import static com.be_notemasterai.exception.ErrorCode.NOT_GROUP_OWNER;
+import static com.be_notemasterai.exception.ErrorCode.SELF_INVITE_NOT_ALLOWED;
+import static com.be_notemasterai.group.type.GroupRole.INVITEE;
+import static com.be_notemasterai.group.type.GroupRole.OWNER;
+
+import com.be_notemasterai.exception.CustomException;
+import com.be_notemasterai.group.dto.GroupListResponse;
+import com.be_notemasterai.group.dto.GroupMemberListResponse;
+import com.be_notemasterai.group.dto.GroupRequest;
+import com.be_notemasterai.group.dto.GroupResponse;
+import com.be_notemasterai.group.dto.GroupUpdateRequest;
+import com.be_notemasterai.group.entity.Group;
+import com.be_notemasterai.group.entity.GroupMember;
+import com.be_notemasterai.group.repository.GroupMemberRepository;
+import com.be_notemasterai.group.repository.GroupRepository;
+import com.be_notemasterai.group.type.GroupRole;
+import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.member.repository.MemberRepository;
+import com.be_notemasterai.note.dto.NoteListResponse;
+import com.be_notemasterai.note.entity.Note;
+import com.be_notemasterai.note.repository.NoteRepository;
+import com.be_notemasterai.note.service.NoteService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GroupService {
+
+  private final GroupRepository groupRepository;
+
+  private final GroupMemberRepository groupMemberRepository;
+
+  private final NoteService noteService;
+
+  private final NoteRepository noteRepository;
+
+  private final MemberRepository memberRepository;
+
+  @Transactional
+  public GroupResponse createGroup(Member member, GroupRequest groupRequest) {
+
+    Group group = Group.of(groupRequest);
+
+    groupRepository.save(group);
+
+    saveGroupMember(member, group, OWNER);
+
+    return GroupResponse.fromEntity(group);
+  }
+
+  @Transactional
+  public void saveGroupMember(Member member, Group group, GroupRole groupRole) {
+
+    GroupMember groupMember = GroupMember.of(member, group, groupRole);
+
+    groupMemberRepository.save(groupMember);
+  }
+
+  @Transactional
+  public Page<NoteListResponse> addNoteToGroup(Member member, Long groupId, Long noteId,
+      Pageable pageable) {
+
+    Note note = noteService.findNoteAndOwner(member, noteId);
+
+    if (note.getGroup() != null) {
+      throw new CustomException(ALREADY_SET_GROUP_NOTE);
+    }
+
+    Group group = groupRepository.findById(groupId)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_GROUP));
+
+    note.setGroup(group);
+
+    return notePage(group, pageable);
+  }
+
+  @Transactional
+  public Page<NoteListResponse> removeNoteFromGroup(Member member, Long groupId, Long noteId,
+      Pageable pageable) {
+
+    Note note = noteService.findNoteAndOwner(member, noteId);
+
+    Group group = groupRepository.findById(groupId)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_GROUP));
+
+    if (note.getGroup() == null) {
+      throw new CustomException(ALREADY_SET_GROUP_NULL);
+    }
+
+    if (!note.getGroup().getId().equals(groupId)) {
+      throw new CustomException(INVALID_GROUP_NOTE);
+    }
+
+    note.setGroup(null);
+
+    return notePage(group, pageable);
+  }
+
+  public Page<GroupListResponse> getGroups(Member member, Pageable pageable) {
+
+    Page<Group> groups = groupRepository.findGroupsByMember(member, pageable);
+
+    return groups.map(
+        group -> GroupListResponse.fromEntity(group, groupMemberRepository.countByGroup(group)));
+  }
+
+  public GroupResponse getGroup(Member member, Long groupId) {
+
+    Group group = validGroupMember(member, groupId).getFirst();
+
+    return GroupResponse.fromEntity(group);
+  }
+
+  @Transactional
+  public void deleteGroup(Member member, Long groupId) {
+
+    Pair<Group, GroupMember> pair = validGroupMember(member, groupId);
+
+    if (pair.getSecond().getGroupRole() != OWNER) {
+      throw new CustomException(NOT_GROUP_OWNER);
+    }
+
+    long memberCount = groupMemberRepository.countByGroup(pair.getFirst());
+
+    if (memberCount > 1) {
+      throw new CustomException(EXIST_GROUP_MEMBER);
+    }
+
+    List<Note> notes = noteRepository.findByGroup(pair.getFirst());
+    noteSetGroupNull(notes);
+
+    groupRepository.delete(pair.getFirst());
+  }
+
+  @Transactional
+  public GroupResponse updateGroup(Member member, Long groupId,
+      GroupUpdateRequest groupUpdateRequest) {
+
+    Pair<Group, GroupMember> pair = validGroupMember(member, groupId);
+
+    if (pair.getSecond().getGroupRole() != OWNER) {
+      throw new CustomException(NOT_GROUP_OWNER);
+    }
+
+    pair.getFirst().update(groupUpdateRequest);
+
+    return GroupResponse.fromEntity(pair.getFirst());
+  }
+
+  @Transactional
+  public void inviteMember(Member owner, Long groupId, Long memberId) {
+
+    Pair<Group, GroupMember> pair = validGroupMember(owner, groupId);
+
+    if (owner.getId().equals(memberId)) {
+      throw new CustomException(SELF_INVITE_NOT_ALLOWED);
+    }
+
+    if (pair.getSecond().getGroupRole() != OWNER) {
+      throw new CustomException(NOT_GROUP_OWNER);
+    }
+
+    Member inviteMember = memberRepository.findById(memberId)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
+
+    boolean existMember = groupMemberRepository.existsByMemberAndGroup(inviteMember,
+        pair.getFirst());
+
+    if (existMember) {
+      throw new CustomException(ALREADY_SET_GROUP_MEMBER);
+    }
+
+    saveGroupMember(inviteMember, pair.getFirst(), INVITEE);
+  }
+
+  @Transactional
+  public void leaveGroup(Member member, Long groupId) {
+
+    Pair<Group, GroupMember> pair = validGroupMember(member, groupId);
+
+    if (pair.getSecond().getGroupRole() == OWNER) {
+      throw new CustomException(CANNOT_LEAVE_GROUP_AS_OWNER);
+    }
+
+    removeGroupMemberAndNotes(pair.getSecond(), member, pair.getFirst());
+  }
+
+  public Page<NoteListResponse> getNotesInGroup(Member member, Long groupId, Pageable pageable) {
+
+    Pair<Group, GroupMember> pair = validGroupMember(member, groupId);
+
+    return notePage(pair.getFirst(), pageable);
+  }
+
+  @Transactional
+  public void removeMemberFromGroup(Member member, Long groupId, Long memberId) {
+
+    if (member.getId().equals(memberId)) {
+      throw new CustomException(CANNOT_REMOVE_GROUP_OWNER);
+    }
+
+    Pair<Group, GroupMember> pair = validGroupMember(member, groupId);
+
+    if (pair.getSecond().getGroupRole() != OWNER) {
+      throw new CustomException(NOT_GROUP_OWNER);
+    }
+
+    Member targetMember = memberRepository.findById(memberId)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
+
+    GroupMember groupMember = groupMemberRepository.findByMemberAndGroup(targetMember,
+        pair.getFirst()).orElseThrow(() -> new CustomException(INVALID_GROUP_MEMBER));
+
+    removeGroupMemberAndNotes(groupMember, targetMember, pair.getFirst());
+  }
+
+
+  public Page<GroupMemberListResponse> getGroupMembers(Member member, Long groupId, Pageable pageable) {
+
+    Pair<Group, GroupMember> pair = validGroupMember(member, groupId);
+
+    Page<GroupMember> groupMembers = groupMemberRepository.findByGroup(pair.getFirst(), pageable);
+
+    return groupMembers.map(GroupMemberListResponse::fromEntity);
+  }
+
+  private void removeGroupMemberAndNotes(GroupMember groupMember, Member member, Group group) {
+
+    groupMemberRepository.delete(groupMember);
+
+    List<Note> notes = noteRepository.findByOwnerAndGroup(member, group);
+    noteSetGroupNull(notes);
+  }
+
+  private Page<NoteListResponse> notePage(Group group, Pageable pageable) {
+
+    Page<Note> notes = noteRepository.findByGroup(group, pageable);
+
+    return notes.map(NoteListResponse::fromEntity);
+  }
+
+  private Pair<Group, GroupMember> validGroupMember(Member member, Long groupId) {
+
+    Group group = groupRepository.findById(groupId)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_GROUP));
+
+    GroupMember groupMember = groupMemberRepository.findByMemberAndGroup(member, group)
+        .orElseThrow(() -> new CustomException(INVALID_GROUP_MEMBER));
+
+    return Pair.of(group, groupMember);
+  }
+
+  private void noteSetGroupNull(List<Note> notes) {
+    notes.forEach(note -> note.setGroup(null));
+  }
+}

--- a/src/main/java/com/be_notemasterai/group/type/GroupRole.java
+++ b/src/main/java/com/be_notemasterai/group/type/GroupRole.java
@@ -1,0 +1,5 @@
+package com.be_notemasterai.group.type;
+
+public enum GroupRole {
+  OWNER, INVITEE
+}

--- a/src/main/java/com/be_notemasterai/member/controller/MemberController.java
+++ b/src/main/java/com/be_notemasterai/member/controller/MemberController.java
@@ -1,11 +1,14 @@
 package com.be_notemasterai.member.controller;
 
+import com.be_notemasterai.member.dto.MemberInfoResponse;
 import com.be_notemasterai.member.dto.NicknameRequestDto;
 import com.be_notemasterai.member.entity.Member;
 import com.be_notemasterai.member.service.MemberService;
 import com.be_notemasterai.security.resolver.CurrentMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,5 +28,12 @@ public class MemberController {
     memberService.setupNickname(member, nicknameRequestDto.nickname());
 
     return ResponseEntity.ok().build();
+  }
+
+  @GetMapping("/{tag}")
+  public ResponseEntity<MemberInfoResponse> getMember(@CurrentMember Member member,
+      @PathVariable String tag) {
+
+    return ResponseEntity.ok(memberService.getMember(member, tag));
   }
 }

--- a/src/main/java/com/be_notemasterai/member/dto/MemberInfoResponse.java
+++ b/src/main/java/com/be_notemasterai/member/dto/MemberInfoResponse.java
@@ -1,0 +1,22 @@
+package com.be_notemasterai.member.dto;
+
+import com.be_notemasterai.member.entity.Member;
+import lombok.Builder;
+
+@Builder
+public record MemberInfoResponse(
+
+    Long memberId,
+    String nickname,
+    String profileImageUrl
+) {
+
+  public static MemberInfoResponse fromEntity(Member getMemberByTag) {
+
+    return MemberInfoResponse.builder()
+        .memberId(getMemberByTag.getId())
+        .nickname(getMemberByTag.getNickname())
+        .profileImageUrl(getMemberByTag.getProfileImageUrl())
+        .build();
+  }
+}

--- a/src/main/java/com/be_notemasterai/member/repository/MemberRepository.java
+++ b/src/main/java/com/be_notemasterai/member/repository/MemberRepository.java
@@ -11,4 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   boolean existsByTag(String tag);
 
   boolean existsByNickname(String nickname);
+
+  Optional<Member> findByTag(String tag);
 }

--- a/src/main/java/com/be_notemasterai/member/service/MemberService.java
+++ b/src/main/java/com/be_notemasterai/member/service/MemberService.java
@@ -2,8 +2,11 @@ package com.be_notemasterai.member.service;
 
 import static com.be_notemasterai.exception.ErrorCode.ALREADY_SET_NICKNAME;
 import static com.be_notemasterai.exception.ErrorCode.EXISTS_NICKNAME;
+import static com.be_notemasterai.exception.ErrorCode.NOT_FOUND_MEMBER;
+import static com.be_notemasterai.exception.ErrorCode.SELF_TAG_SEARCH_NOT_ALLOWED;
 
 import com.be_notemasterai.exception.CustomException;
+import com.be_notemasterai.member.dto.MemberInfoResponse;
 import com.be_notemasterai.member.entity.Member;
 import com.be_notemasterai.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,5 +34,17 @@ public class MemberService {
     }
 
     member.setNickname(nickname);
+  }
+
+  public MemberInfoResponse getMember(Member member, String tag) {
+
+    Member getMemberByTag = memberRepository.findByTag(tag)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
+
+    if (member.getId().equals(getMemberByTag.getId())) {
+      throw new CustomException(SELF_TAG_SEARCH_NOT_ALLOWED);
+    }
+
+    return MemberInfoResponse.fromEntity(getMemberByTag);
   }
 }

--- a/src/main/java/com/be_notemasterai/note/controller/NoteController.java
+++ b/src/main/java/com/be_notemasterai/note/controller/NoteController.java
@@ -16,7 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,7 +43,7 @@ public class NoteController {
     return ResponseEntity.ok(noteService.getNote(owner, noteId));
   }
 
-  @PostMapping("/{noteId}")
+  @PutMapping("/{noteId}")
   public ResponseEntity<NoteResponse> updateNote(@CurrentMember Member owner,
       @PathVariable Long noteId, @RequestBody NoteUpdateRequest noteUpdateRequest) {
 

--- a/src/main/java/com/be_notemasterai/note/dto/NoteListResponse.java
+++ b/src/main/java/com/be_notemasterai/note/dto/NoteListResponse.java
@@ -9,6 +9,8 @@ public record NoteListResponse(
 
     Long noteId,
     Long ownerId,
+    String ownerProfileImageUrl,
+    Long groupId,
     String ownerNickname,
     String title,
     LocalDateTime createdAt
@@ -19,6 +21,8 @@ public record NoteListResponse(
     return NoteListResponse.builder()
         .noteId(note.getId())
         .ownerId(note.getOwner().getId())
+        .ownerProfileImageUrl(note.getOwner().getProfileImageUrl())
+        .groupId(note.getGroup() != null ? note.getGroup().getId() : null)
         .ownerNickname(note.getOwner().getNickname())
         .title(note.getTitle())
         .createdAt(note.getCreatedAt())

--- a/src/main/java/com/be_notemasterai/note/entity/Note.java
+++ b/src/main/java/com/be_notemasterai/note/entity/Note.java
@@ -4,6 +4,7 @@ import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+import com.be_notemasterai.group.entity.Group;
 import com.be_notemasterai.member.entity.Member;
 import com.be_notemasterai.note.dto.NoteUpdateRequest;
 import jakarta.persistence.Column;
@@ -19,6 +20,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -39,6 +41,11 @@ public class Note {
   @ManyToOne(fetch = LAZY)
   private Member owner;
 
+  @Setter
+  @JoinColumn(name = "group_id")
+  @ManyToOne(fetch = LAZY)
+  private Group group;
+
   @Column(nullable = false)
   private String title;
 
@@ -56,6 +63,7 @@ public class Note {
 
     return Note.builder()
         .owner(owner)
+        .group(null)
         .title(title)
         .originalText(originalText)
         .summary(summary)

--- a/src/main/java/com/be_notemasterai/note/repository/NoteRepository.java
+++ b/src/main/java/com/be_notemasterai/note/repository/NoteRepository.java
@@ -1,7 +1,9 @@
 package com.be_notemasterai.note.repository;
 
+import com.be_notemasterai.group.entity.Group;
 import com.be_notemasterai.member.entity.Member;
 import com.be_notemasterai.note.entity.Note;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +11,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface NoteRepository extends JpaRepository<Note, Long> {
 
   Page<Note> findByOwner(Member member, Pageable pageable);
+
+  Page<Note> findByGroup(Group group, Pageable pageable);
+
+  List<Note> findByGroup(Group group);
+
+  List<Note> findByOwnerAndGroup(Member member, Group group);
 }

--- a/src/main/java/com/be_notemasterai/note/service/NoteService.java
+++ b/src/main/java/com/be_notemasterai/note/service/NoteService.java
@@ -61,7 +61,7 @@ public class NoteService {
     noteRepository.delete(note);
   }
 
-  private Note findNoteAndOwner(Member owner, Long noteId) {
+  public Note findNoteAndOwner(Member owner, Long noteId) {
 
     Note note = noteRepository.findById(noteId)
         .orElseThrow(() -> new CustomException(NOT_FOUND_NOTE));

--- a/src/test/java/com/be_notemasterai/group/service/GroupServiceTest.java
+++ b/src/test/java/com/be_notemasterai/group/service/GroupServiceTest.java
@@ -1,0 +1,397 @@
+package com.be_notemasterai.group.service;
+
+import static com.be_notemasterai.exception.ErrorCode.ALREADY_SET_GROUP_MEMBER;
+import static com.be_notemasterai.exception.ErrorCode.ALREADY_SET_GROUP_NOTE;
+import static com.be_notemasterai.exception.ErrorCode.ALREADY_SET_GROUP_NULL;
+import static com.be_notemasterai.exception.ErrorCode.CANNOT_LEAVE_GROUP_AS_OWNER;
+import static com.be_notemasterai.exception.ErrorCode.EXIST_GROUP_MEMBER;
+import static com.be_notemasterai.exception.ErrorCode.INVALID_GROUP_NOTE;
+import static com.be_notemasterai.exception.ErrorCode.NOT_FOUND_GROUP;
+import static com.be_notemasterai.exception.ErrorCode.NOT_GROUP_OWNER;
+import static com.be_notemasterai.exception.ErrorCode.SELF_INVITE_NOT_ALLOWED;
+import static com.be_notemasterai.group.type.GroupRole.INVITEE;
+import static com.be_notemasterai.group.type.GroupRole.OWNER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.be_notemasterai.exception.CustomException;
+import com.be_notemasterai.group.dto.GroupListResponse;
+import com.be_notemasterai.group.dto.GroupRequest;
+import com.be_notemasterai.group.dto.GroupResponse;
+import com.be_notemasterai.group.dto.GroupUpdateRequest;
+import com.be_notemasterai.group.entity.Group;
+import com.be_notemasterai.group.entity.GroupMember;
+import com.be_notemasterai.group.repository.GroupMemberRepository;
+import com.be_notemasterai.group.repository.GroupRepository;
+import com.be_notemasterai.member.entity.Member;
+import com.be_notemasterai.member.repository.MemberRepository;
+import com.be_notemasterai.note.dto.NoteListResponse;
+import com.be_notemasterai.note.entity.Note;
+import com.be_notemasterai.note.repository.NoteRepository;
+import com.be_notemasterai.note.service.NoteService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class GroupServiceTest {
+
+  @Mock
+  private GroupRepository groupRepository;
+
+  @Mock
+  private GroupMemberRepository groupMemberRepository;
+
+  @Mock
+  private NoteService noteService;
+
+  @Mock
+  private NoteRepository noteRepository;
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  @InjectMocks
+  private GroupService groupService;
+
+  private Member owner;
+  private Member invitee;
+  private Group group;
+  private Note note;
+  private GroupMember groupMember;
+
+  @BeforeEach
+  void setUp() {
+    owner = Member.builder()
+        .id(1L)
+        .tag("@tag")
+        .build();
+
+    invitee = Member.builder()
+        .id(2L)
+        .tag("@tagTag")
+        .build();
+
+    group = Group.builder()
+        .id(1L)
+        .groupName("그룹명")
+        .groupDescription("그룹 설명")
+        .build();
+
+    groupMember = GroupMember.builder()
+        .id(1L)
+        .member(owner)
+        .groupRole(OWNER)
+        .build();
+  }
+
+  @Test
+  @DisplayName("그룹 생성에 성공한다")
+  void create_group_success() {
+    // given
+    GroupRequest groupRequest = new GroupRequest("그룹", "설명");
+    // when
+    groupService.createGroup(owner, groupRequest);
+    // then
+    verify(groupRepository).save(any());
+    verify(groupMemberRepository).save(any());
+  }
+
+  @Test
+  @DisplayName("그룹에 노트를 성공적으로 추가한다")
+  void add_note_group_success() {
+    // given
+    note = Note.builder().id(1L).owner(owner).build();
+
+    when(noteService.findNoteAndOwner(owner, note.getId())).thenReturn(note);
+
+    when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+
+    when(noteRepository.findByGroup(group, PageRequest.of(0, 10))).thenReturn(
+        new PageImpl<>(List.of(note), PageRequest.of(0, 10), 1));
+    // when
+    Page<NoteListResponse> noteListResponses = groupService.addNoteToGroup(owner, group.getId(),
+        note.getId(), PageRequest.of(0, 10));
+    // then
+    assertNotNull(noteListResponses);
+    assertEquals(1, noteListResponses.getTotalElements());
+  }
+
+  @Test
+  @DisplayName("노트가 그룹이 있으면 예외가 발생한다")
+  void add_note_group_failure_already_set_note() {
+    // given
+    note = Note.builder().id(1L).group(group).build();
+
+    when(noteService.findNoteAndOwner(owner, note.getId())).thenReturn(note);
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> groupService.addNoteToGroup(owner, group.getId(), note.getId(),
+            PageRequest.of(0, 10)));
+    // then
+    assertEquals(ALREADY_SET_GROUP_NOTE, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("그룹이 존재하지 않으면 예외가 발생한다")
+  void add_note_group_failure_not_found_group() {
+    // given
+    note = Note.builder().id(1L).build();
+
+    when(noteService.findNoteAndOwner(owner, note.getId())).thenReturn(note);
+
+    when(groupRepository.findById(group.getId())).thenReturn(Optional.empty());
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> groupService.addNoteToGroup(owner, group.getId(), note.getId(),
+            PageRequest.of(0, 10)));
+    // then
+    assertEquals(NOT_FOUND_GROUP, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("그룹에서 노트를 성공적으로 제거한다")
+  void remove_note_from_group_success() {
+    // given
+    note = Note.builder().id(1L).owner(owner).group(group).build();
+
+    when(noteService.findNoteAndOwner(owner, note.getId())).thenReturn(note);
+
+    when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+
+    when(noteRepository.findByGroup(group, PageRequest.of(0, 10))).thenReturn(
+        new PageImpl<>(List.of(note), PageRequest.of(0, 10), 1));
+    // when
+    groupService.removeNoteFromGroup(owner, group.getId(), note.getId(), PageRequest.of(0, 10));
+    // then
+    assertNull(note.getGroup());
+  }
+
+  @Test
+  @DisplayName("이미 노트가 제거되었으면 예외가 발생한다")
+  void remove_note_from_group_failure_already_remove() {
+    // given
+    note = Note.builder().id(1L).owner(owner).build();
+
+    when(noteService.findNoteAndOwner(owner, note.getId())).thenReturn(note);
+
+    when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> groupService.removeNoteFromGroup(owner, group.getId(), note.getId(),
+            PageRequest.of(0, 10)));
+    // then
+    assertEquals(e.getErrorCode(), ALREADY_SET_GROUP_NULL);
+  }
+
+  @Test
+  @DisplayName("그룹에 속한 노트가 아니면 예외가 발생한다")
+  void remove_note_from_group_failure_invalid_group() {
+    // given
+    Group anotherGroup = Group.builder().id(2L).build();
+    note = Note.builder().id(1L).owner(owner).group(anotherGroup).build();
+
+    when(noteService.findNoteAndOwner(owner, note.getId())).thenReturn(note);
+
+    when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> groupService.removeNoteFromGroup(owner, group.getId(), note.getId(),
+            PageRequest.of(0, 10)));
+    // then
+    assertEquals(INVALID_GROUP_NOTE, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("그룹 목록 조회에 성공한다")
+  void get_groups_success() {
+    // given
+    Group anotherGroup = Group.builder().id(2L).build();
+
+    when(groupRepository.findGroupsByMember(owner, PageRequest.of(0, 10))).thenReturn(
+        new PageImpl<>(List.of(group, anotherGroup), PageRequest.of(0, 10), 2));
+    // when
+    Page<GroupListResponse> groups = groupService.getGroups(owner, PageRequest.of(0, 10));
+    // then
+    assertEquals(2, groups.getTotalElements());
+  }
+
+  @Test
+  @DisplayName("그룹 상세 조회에 성공한다")
+  void get_group_success() {
+    // given
+    when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+
+    when(groupMemberRepository.findByMemberAndGroup(owner, group)).thenReturn(
+        Optional.of(groupMember));
+    // when
+    GroupResponse result = groupService.getGroup(owner, group.getId());
+    // then
+    assertEquals(result.groupName(), "그룹명");
+    assertEquals(result.groupDescription(), "그룹 설명");
+  }
+
+  @Test
+  @DisplayName("그룹 삭제에 성공한다")
+  void delete_group_success() {
+    // given
+    when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+
+    when(groupMemberRepository.findByMemberAndGroup(owner, group)).thenReturn(
+        Optional.of(groupMember));
+    // when
+    groupService.deleteGroup(owner, group.getId());
+    // then
+    verify(groupRepository).delete(group);
+  }
+
+  @Test
+  @DisplayName("그룹장이 아니면 예외가 발생한다")
+  void delete_group_failure_not_owner() {
+    // given
+    GroupMember inviteMember = GroupMember.builder().id(2L).group(group).groupRole(INVITEE).build();
+
+    when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+
+    when(groupMemberRepository.findByMemberAndGroup(invitee, group)).thenReturn(
+        Optional.of(inviteMember));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> groupService.deleteGroup(invitee, group.getId()));
+    // then
+    assertEquals(e.getErrorCode(), NOT_GROUP_OWNER);
+  }
+
+  @Test
+  @DisplayName("그룹에 다른 멤버가 남아있으면 예외가 발생한다")
+  void delete_group_failure_exist_member() {
+    // given
+    when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+
+    when(groupMemberRepository.findByMemberAndGroup(owner, group)).thenReturn(
+        Optional.of(groupMember));
+
+    when(groupMemberRepository.countByGroup(group)).thenReturn(2L);
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> groupService.deleteGroup(owner, group.getId()));
+    // then
+    assertEquals(e.getErrorCode(), EXIST_GROUP_MEMBER);
+  }
+
+  @Test
+  @DisplayName("그룹 수정이 성공한다")
+  void update_group_success() {
+    // given
+    when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+
+    when(groupMemberRepository.findByMemberAndGroup(owner, group)).thenReturn(
+        Optional.of(groupMember));
+    // when
+    GroupResponse groupResponse = groupService.updateGroup(owner, group.getId(),
+        new GroupUpdateRequest("새 이름", "새 설명"));
+    // then
+    assertEquals(groupResponse.groupName(), "새 이름");
+    assertEquals(groupResponse.groupDescription(), "새 설명");
+  }
+
+  @Test
+  @DisplayName("그룹에 다른 회원 초대에 성공한다")
+  void invite_member_success() {
+    // given
+    when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+
+    when(groupMemberRepository.findByMemberAndGroup(owner, group)).thenReturn(
+        Optional.of(groupMember));
+
+    when(memberRepository.findById(invitee.getId())).thenReturn(Optional.of(invitee));
+    // when
+    groupService.inviteMember(owner, group.getId(), invitee.getId());
+    // then
+    verify(groupMemberRepository).save(any());
+  }
+
+  @Test
+  @DisplayName("자기 자신을 초대하는 경우 예외가 발생한다")
+  void invite_member_failure_self_invite() {
+    // given
+    when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+
+    when(groupMemberRepository.findByMemberAndGroup(owner, group)).thenReturn(
+        Optional.of(groupMember));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> groupService.inviteMember(owner, group.getId(), owner.getId()));
+    // then
+    assertEquals(e.getErrorCode(), SELF_INVITE_NOT_ALLOWED);
+  }
+
+  @Test
+  @DisplayName("이미 해당 그룹에 속한 경우 예외가 발생한다")
+  void invite_member_failure_already_member() {
+    // given
+    when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+
+    when(groupMemberRepository.findByMemberAndGroup(owner, group)).thenReturn(
+        Optional.of(groupMember));
+
+    when(memberRepository.findById(invitee.getId())).thenReturn(Optional.of(invitee));
+
+    when(groupMemberRepository.existsByMemberAndGroup(invitee, group)).thenReturn(true);
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> groupService.inviteMember(owner, group.getId(), invitee.getId()));
+    // then
+    assertEquals(e.getErrorCode(), ALREADY_SET_GROUP_MEMBER);
+  }
+
+  @Test
+  @DisplayName("그룹에서 성공적으로 탈퇴한다")
+  void leave_group_success() {
+    // given
+    GroupMember anotherMember = GroupMember.builder()
+        .id(2L)
+        .group(group)
+        .member(invitee)
+        .groupRole(INVITEE)
+        .build();
+
+    when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+
+    when(groupMemberRepository.findByMemberAndGroup(invitee, group)).thenReturn(
+        Optional.of(anotherMember));
+    // when
+    groupService.leaveGroup(invitee, group.getId());
+    // then
+    verify(groupMemberRepository).delete(anotherMember);
+  }
+
+  @Test
+  @DisplayName("그룹장인경우 그룹 탈퇴시 예외가 발생한다")
+  void leave_group_failure_group_owner() {
+    // given
+    when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+
+    when(groupMemberRepository.findByMemberAndGroup(owner, group)).thenReturn(
+        Optional.of(groupMember));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> groupService.leaveGroup(owner, group.getId()));
+    // then
+    assertEquals(e.getErrorCode(), CANNOT_LEAVE_GROUP_AS_OWNER);
+  }
+}

--- a/src/test/java/com/be_notemasterai/member/service/MemberServiceTest.java
+++ b/src/test/java/com/be_notemasterai/member/service/MemberServiceTest.java
@@ -2,13 +2,16 @@ package com.be_notemasterai.member.service;
 
 import static com.be_notemasterai.exception.ErrorCode.ALREADY_SET_NICKNAME;
 import static com.be_notemasterai.exception.ErrorCode.EXISTS_NICKNAME;
+import static com.be_notemasterai.exception.ErrorCode.SELF_TAG_SEARCH_NOT_ALLOWED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import com.be_notemasterai.exception.CustomException;
+import com.be_notemasterai.member.dto.MemberInfoResponse;
 import com.be_notemasterai.member.entity.Member;
 import com.be_notemasterai.member.repository.MemberRepository;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,6 +34,7 @@ class MemberServiceTest {
   @BeforeEach
   void setUp() {
     member = Member.builder()
+        .id(1L)
         .provider("google")
         .name("이름")
         .profileImageUrl("프로필이미지")
@@ -77,5 +81,29 @@ class MemberServiceTest {
     // then
     assertEquals(e.getMessage(), "이미 존재하는 닉네임 입니다.");
     assertEquals(e.getErrorCode(), EXISTS_NICKNAME);
+  }
+
+  @Test
+  @DisplayName("회원 조회에 성공한다")
+  void get_member_success() {
+    // given
+    Member anotherMember = Member.builder().id(2L).nickname("닉").tag("@tagTag").build();
+    when(memberRepository.findByTag(anotherMember.getTag())).thenReturn(Optional.of(anotherMember));
+    // when
+    MemberInfoResponse result = memberService.getMember(member, anotherMember.getTag());
+    // then
+    assertEquals(result.nickname(), anotherMember.getNickname());
+  }
+
+  @Test
+  @DisplayName("자기 자신을 조회하면 예외가 발생한다")
+  void get_member_failure_self_search() {
+    // given
+    when(memberRepository.findByTag(member.getTag())).thenReturn(Optional.of(member));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> memberService.getMember(member, member.getTag()));
+    // then
+    assertEquals(e.getErrorCode(), SELF_TAG_SEARCH_NOT_ALLOWED);
   }
 }


### PR DESCRIPTION
## 🛠️ 작업 내용 (What)
- Group 관련 구현
## 📌 작업 이유 (Why)
- 노트를 그룹 단위로 관리하기 위해 구현
## ✨ 변경 사항 (Changes)
- 그룹 생성 기능
  - 그룹 생성 시 자동으로 그룹 멤버 테이블에 저장
- 그룹에 노트 추가 기능
  - 하나의 노트는 하나의 그룹에만 들어갈 수 있음(그룹에 여러 노트 저장 가능)
- 그룹 노트 삭제 기능
  - 노트의 생성자는 그룹에 추가된 노트 삭제 가능
- 그룹 목록 조회 기능
  - 페이징 처리되어 목록 조회 가능
- 그룹 조회 기능
- 그룹 삭제 기능
  - 그룹장만 그룹 삭제 가능
  - 그룹에 회원들이 남아있는 경우 삭제가 불가능
  - 그룹이 삭제되면 그룹에 속한 노트들은 그룹 자동 제거
- 그룹 수정 기능
  - 그룹장만 그룹 명, 그룹 설명 필드 수정 가능
- 그룹 초대 기능
  - 자기 자신은 초대 불가능
  - 그룹장만 초대 가능
- 그룹 떠나기 기능
  - 그룹장은 떠나기 불가능
  - 그룹을 떠나게 되면 본인이 등록한 노트는 그룹에서 자동 제거
- 그룹 노트 목록 조회 기능
- 그룹 회원 강제 퇴장 기능
  - 그룹장 본인 강제 퇴장 불가능
  - 그룹장만 강제 퇴장 사용 가능
  - 강제 퇴장 된 회원은 그룹에 속한 노트들도 자동 제거
- 그룹 멤버 조회 기능
  - 페이징 처리되어 그룹 멤버 조회 가능
  - 회원들의 pk, 닉네임, 프로필이미지, 회원유형 등을 반환하며 회원 유형으로 정렬
- 특정 회원 조회 기능
  - 회원가입 시 생성된 tag 를 서로 공유하여 회원 조회 가능
## ✅ 테스트 (Tests)
- [ ] 회원 조회에 성공한다
- [ ] 자기 자신을 조회하면 예외가 발생한다
- [ ] 그룹 생성에 성공한다
- [ ] 그룹에 노트를 성공적으로 추가한다
- [ ] 노트가 그룹이 있으면 예외가 발생한다
- [ ] 그룹이 존재하지 않으면 예외가 발생한다
- [ ] 그룹에서 노트를 성공적으로 제거한다
- [ ] 이미 노트가 제거되었으면 예외가 발생한다
- [ ] 그룹에 속한 노트가 아니면 예외가 발생한다
- [ ] 그룹 목록 조회에 성공한다
- [ ] 그룹 상세 조회에 성공한다
- [ ] 그룹 삭제에 성공한다
- [ ] 그룹장이 아니면 예외가 발생한다
- [ ] 그룹에 다른 멤버가 남아있으면 예외가 발생한다
- [ ] 그룹 수정이 성공한다
- [ ] 그룹에 다른 회원 초대에 성공한다
- [ ] 자기 자신을 초대하는 경우 예외가 발생한다
- [ ] 이미 해당 그룹에 속한 경우 예외가 발생한다
- [ ] 그룹에서 성공적으로 탈퇴한다
- [ ] 그룹장인경우 그룹 탈퇴시 예외가 발생한다