### PR TITLE
✨feat: member 관련 구현

### DIFF
--- a/src/main/java/com/be_notemasterai/exception/ErrorCode.java
+++ b/src/main/java/com/be_notemasterai/exception/ErrorCode.java
@@ -24,9 +24,11 @@ public enum ErrorCode {
   INVALID_GROUP_MEMBER(BAD_REQUEST, "그룹에 속한 회원이 아닙니다."),
   SELF_TAG_SEARCH_NOT_ALLOWED(BAD_REQUEST, "자기 자신은 태그로 조회할 수 없습니다."),
   SELF_INVITE_NOT_ALLOWED(BAD_REQUEST, "자기 자신은 그룹에 초대할 수 없습니다."),
-  EXIST_GROUP_MEMBER(BAD_REQUEST, "그룹에 회원이 존재하는 경우 삭제할 수 없습니다"),
+  EXISTS_GROUP_MEMBER(BAD_REQUEST, "그룹에 회원이 존재하는 경우 삭제할 수 없습니다"),
   CANNOT_LEAVE_GROUP_AS_OWNER(BAD_REQUEST, "그룹장은 그룹을 떠날 수 없습니다."),
   CANNOT_REMOVE_GROUP_OWNER(BAD_REQUEST, "그룹장은 그룹에서 제거할 수 없습니다."),
+  ALREADY_WITHDRAWN_MEMBER(BAD_REQUEST, "탈퇴한 회원입니다."),
+  INVALID_TAG(BAD_REQUEST, "태그 값이 맞지 않거나, 시간이 초과되었습니다."),
   // 401 UNAUTHORIZED
   INVALID_TOKEN(UNAUTHORIZED, "유효하지 않은 토큰입니다."),
   INVALID_REFRESH_TOKEN(UNAUTHORIZED, "리프레쉬 토큰이 유효하지 않습니다."),

--- a/src/main/java/com/be_notemasterai/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/be_notemasterai/group/repository/GroupMemberRepository.java
@@ -3,6 +3,7 @@ package com.be_notemasterai.group.repository;
 import com.be_notemasterai.group.entity.Group;
 import com.be_notemasterai.group.entity.GroupMember;
 import com.be_notemasterai.member.entity.Member;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,4 +18,8 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
   boolean existsByMemberAndGroup(Member member, Group group);
 
   Page<GroupMember> findByGroup(Group group, Pageable pageable);
+
+  Long countByMember(Member member);
+
+  List<GroupMember> findByMember(Member member);
 }

--- a/src/main/java/com/be_notemasterai/group/service/GroupService.java
+++ b/src/main/java/com/be_notemasterai/group/service/GroupService.java
@@ -5,7 +5,7 @@ import static com.be_notemasterai.exception.ErrorCode.ALREADY_SET_GROUP_NOTE;
 import static com.be_notemasterai.exception.ErrorCode.ALREADY_SET_GROUP_NULL;
 import static com.be_notemasterai.exception.ErrorCode.CANNOT_LEAVE_GROUP_AS_OWNER;
 import static com.be_notemasterai.exception.ErrorCode.CANNOT_REMOVE_GROUP_OWNER;
-import static com.be_notemasterai.exception.ErrorCode.EXIST_GROUP_MEMBER;
+import static com.be_notemasterai.exception.ErrorCode.EXISTS_GROUP_MEMBER;
 import static com.be_notemasterai.exception.ErrorCode.INVALID_GROUP_MEMBER;
 import static com.be_notemasterai.exception.ErrorCode.INVALID_GROUP_NOTE;
 import static com.be_notemasterai.exception.ErrorCode.NOT_FOUND_GROUP;
@@ -142,7 +142,7 @@ public class GroupService {
     long memberCount = groupMemberRepository.countByGroup(pair.getFirst());
 
     if (memberCount > 1) {
-      throw new CustomException(EXIST_GROUP_MEMBER);
+      throw new CustomException(EXISTS_GROUP_MEMBER);
     }
 
     List<Note> notes = noteRepository.findByGroup(pair.getFirst());
@@ -243,7 +243,7 @@ public class GroupService {
     return groupMembers.map(GroupMemberListResponse::fromEntity);
   }
 
-  private void removeGroupMemberAndNotes(GroupMember groupMember, Member member, Group group) {
+  public void removeGroupMemberAndNotes(GroupMember groupMember, Member member, Group group) {
 
     groupMemberRepository.delete(groupMember);
 

--- a/src/main/java/com/be_notemasterai/member/controller/MemberController.java
+++ b/src/main/java/com/be_notemasterai/member/controller/MemberController.java
@@ -1,12 +1,17 @@
 package com.be_notemasterai.member.controller;
 
 import com.be_notemasterai.member.dto.MemberInfoResponse;
+import com.be_notemasterai.member.dto.MemberUpdateRequest;
+import com.be_notemasterai.member.dto.MyInfoResponse;
 import com.be_notemasterai.member.dto.NicknameRequestDto;
 import com.be_notemasterai.member.entity.Member;
 import com.be_notemasterai.member.service.MemberService;
 import com.be_notemasterai.security.resolver.CurrentMember;
+import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -35,5 +40,35 @@ public class MemberController {
       @PathVariable String tag) {
 
     return ResponseEntity.ok(memberService.getMember(member, tag));
+  }
+
+  @GetMapping("/me")
+  public ResponseEntity<MyInfoResponse> getMyInfo(@CurrentMember Member member) {
+
+    return ResponseEntity.ok(memberService.getMyInfo(member));
+  }
+
+  @PutMapping("/me")
+  public ResponseEntity<MyInfoResponse> updateInfo(@CurrentMember Member member,
+      @RequestBody MemberUpdateRequest memberUpdateRequest) {
+
+    return ResponseEntity.ok(memberService.updateInfo(member, memberUpdateRequest));
+  }
+
+  @DeleteMapping
+  public ResponseEntity<BigDecimal> withdraw(@CurrentMember Member member) {
+
+    BigDecimal balance = memberService.withdraw(member);
+
+    return ResponseEntity.ok(balance);
+  }
+
+  @PutMapping("/rejoin")
+  public ResponseEntity<Void> rejoin(
+      @CookieValue(value = "tag", required = false) String tag) {
+
+    memberService.rejoin(tag);
+
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/be_notemasterai/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/com/be_notemasterai/member/dto/MemberUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.be_notemasterai.member.dto;
+
+public record MemberUpdateRequest(String nickname) {
+}

--- a/src/main/java/com/be_notemasterai/member/dto/MyInfoResponse.java
+++ b/src/main/java/com/be_notemasterai/member/dto/MyInfoResponse.java
@@ -1,0 +1,34 @@
+package com.be_notemasterai.member.dto;
+
+import com.be_notemasterai.member.entity.Member;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record MyInfoResponse(
+
+    String provider,
+    String profileImageUrl,
+    String nickname,
+    String tag,
+    LocalDateTime createdAt,
+    Long myNotes,
+    Long myGroups,
+    LocalDateTime subscribeEndedAt
+) {
+
+  public static MyInfoResponse fromEntity(Member member, Long countNote, Long countGroups,
+      LocalDateTime subscribeEndedAt) {
+
+    return MyInfoResponse.builder()
+        .provider(member.getProvider())
+        .profileImageUrl(member.getProfileImageUrl())
+        .nickname(member.getNickname())
+        .tag(member.getTag())
+        .createdAt(member.getCreatedAt())
+        .myNotes(countNote)
+        .myGroups(countGroups)
+        .subscribeEndedAt(subscribeEndedAt)
+        .build();
+  }
+}

--- a/src/main/java/com/be_notemasterai/member/entity/Member.java
+++ b/src/main/java/com/be_notemasterai/member/entity/Member.java
@@ -55,6 +55,10 @@ public class Member {
   @Column(name = "created_at")
   private LocalDateTime createdAt;
 
+  @Column(name = "deleted_at")
+  @Setter
+  private LocalDateTime deletedAt;
+
   public static Member of(OAuth2UserInfo oAuth2UserInfo, String tag) {
 
     return Member.builder()

--- a/src/main/java/com/be_notemasterai/member/repository/MemberRepository.java
+++ b/src/main/java/com/be_notemasterai/member/repository/MemberRepository.java
@@ -3,6 +3,8 @@ package com.be_notemasterai.member.repository;
 import com.be_notemasterai.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
@@ -12,5 +14,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
   boolean existsByNickname(String nickname);
 
-  Optional<Member> findByTag(String tag);
+  @Query("SELECT m FROM Member m WHERE m.tag = :tag AND m.deletedAt IS NULL")
+  Optional<Member> findByTag(@Param("tag") String tag);
 }

--- a/src/main/java/com/be_notemasterai/member/service/MemberService.java
+++ b/src/main/java/com/be_notemasterai/member/service/MemberService.java
@@ -2,13 +2,34 @@ package com.be_notemasterai.member.service;
 
 import static com.be_notemasterai.exception.ErrorCode.ALREADY_SET_NICKNAME;
 import static com.be_notemasterai.exception.ErrorCode.EXISTS_NICKNAME;
+import static com.be_notemasterai.exception.ErrorCode.EXISTS_GROUP_MEMBER;
+import static com.be_notemasterai.exception.ErrorCode.INVALID_TAG;
 import static com.be_notemasterai.exception.ErrorCode.NOT_FOUND_MEMBER;
+import static com.be_notemasterai.exception.ErrorCode.NOT_FOUND_PAYMENT;
 import static com.be_notemasterai.exception.ErrorCode.SELF_TAG_SEARCH_NOT_ALLOWED;
+import static com.be_notemasterai.group.type.GroupRole.OWNER;
+import static com.be_notemasterai.subscribe.type.SubscriptionStatus.ACTIVE;
 
 import com.be_notemasterai.exception.CustomException;
+import com.be_notemasterai.group.entity.GroupMember;
+import com.be_notemasterai.group.repository.GroupMemberRepository;
+import com.be_notemasterai.group.repository.GroupRepository;
+import com.be_notemasterai.group.service.GroupService;
 import com.be_notemasterai.member.dto.MemberInfoResponse;
+import com.be_notemasterai.member.dto.MemberUpdateRequest;
+import com.be_notemasterai.member.dto.MyInfoResponse;
 import com.be_notemasterai.member.entity.Member;
 import com.be_notemasterai.member.repository.MemberRepository;
+import com.be_notemasterai.note.repository.NoteRepository;
+import com.be_notemasterai.payment.entity.Payment;
+import com.be_notemasterai.payment.repository.PaymentRepository;
+import com.be_notemasterai.payment.service.PaymentService;
+import com.be_notemasterai.subscribe.entity.Subscribe;
+import com.be_notemasterai.subscribe.repository.SubscribeRepository;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +41,20 @@ public class MemberService {
 
   private final MemberRepository memberRepository;
 
+  private final NoteRepository noteRepository;
+
+  private final GroupMemberRepository groupMemberRepository;
+
+  private final SubscribeRepository subscribeRepository;
+
+  private final PaymentService paymentService;
+
+  private final PaymentRepository paymentRepository;
+
+  private final GroupRepository groupRepository;
+
+  private final GroupService groupService;
+
   @Transactional
   public void setupNickname(Member member, String nickname) {
 
@@ -27,13 +62,7 @@ public class MemberService {
       throw new CustomException(ALREADY_SET_NICKNAME);
     }
 
-    boolean existsNickname = memberRepository.existsByNickname(nickname);
-
-    if (existsNickname) {
-      throw new CustomException(EXISTS_NICKNAME);
-    }
-
-    member.setNickname(nickname);
+    checkAndSetNickname(member, nickname);
   }
 
   public MemberInfoResponse getMember(Member member, String tag) {
@@ -46,5 +75,99 @@ public class MemberService {
     }
 
     return MemberInfoResponse.fromEntity(getMemberByTag);
+  }
+
+  public MyInfoResponse getMyInfo(Member member) {
+
+    Long countNote = noteRepository.countByOwner(member);
+
+    Long countGroups = groupMemberRepository.countByMember(member);
+
+    LocalDateTime subscribeEndedAt =
+        subscribeRepository.findActiveSubscribeEndedAtBySubscriber(member);
+
+    return MyInfoResponse.fromEntity(member, countNote, countGroups, subscribeEndedAt);
+  }
+
+  @Transactional
+  public MyInfoResponse updateInfo(Member member, MemberUpdateRequest memberUpdateRequest) {
+
+    checkAndSetNickname(member, memberUpdateRequest.nickname());
+
+    return getMyInfo(member);
+  }
+
+  @Transactional
+  public BigDecimal withdraw(Member member) {
+
+    Subscribe activeSubscribe = subscribeRepository.findBySubscriberAndSubscriptionStatus(member,
+        ACTIVE).orElse(null);
+
+    if (activeSubscribe != null) {
+
+      Payment payment = paymentRepository.findById(activeSubscribe.getPaymentId())
+          .orElseThrow(() -> new CustomException(NOT_FOUND_PAYMENT));
+
+      long daysUsed = Duration.between(activeSubscribe.getStartedAt(), LocalDateTime.now())
+          .toDays();
+
+      return paymentService.calculateRefundAmount(payment.getAmount(), daysUsed);
+    }
+
+    processMemberWithdrawal(member);
+
+    return null;
+  }
+
+  @Transactional
+  public void rejoin(String tag) {
+
+    if (tag == null || tag.isEmpty()) {
+      throw new CustomException(INVALID_TAG);
+    }
+
+    Member member = memberRepository.findByTag(tag)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
+
+    member.setDeletedAt(null);
+  }
+
+  private void processMemberWithdrawal(Member member) {
+
+    List<GroupMember> groupMembers = groupMemberRepository.findByMember(member);
+
+    for (GroupMember groupMember : groupMembers) {
+
+      if (groupMember.getGroupRole() == OWNER) {
+
+        long memberCount = groupMemberRepository.countByGroup(groupMember.getGroup());
+
+        if (memberCount == 1) {
+          groupRepository.delete(groupMember.getGroup());
+        } else {
+          throw new CustomException(EXISTS_GROUP_MEMBER);
+        }
+      } else {
+        groupService.removeGroupMemberAndNotes(groupMember, member, groupMember.getGroup());
+      }
+    }
+
+    member.setDeletedAt(LocalDateTime.now());
+    member.setNickname(generateRandomNickname());
+  }
+
+  private void checkAndSetNickname(Member member, String nickname) {
+
+    boolean existsNickname = memberRepository.existsByNickname(nickname);
+
+    if (existsNickname) {
+      throw new CustomException(EXISTS_NICKNAME);
+    }
+
+    member.setNickname(nickname);
+  }
+
+  private String generateRandomNickname() {
+    return "user_" + System.currentTimeMillis();
   }
 }

--- a/src/main/java/com/be_notemasterai/note/repository/NoteRepository.java
+++ b/src/main/java/com/be_notemasterai/note/repository/NoteRepository.java
@@ -17,4 +17,6 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
   List<Note> findByGroup(Group group);
 
   List<Note> findByOwnerAndGroup(Member member, Group group);
+
+  Long countByOwner(Member member);
 }

--- a/src/main/java/com/be_notemasterai/payment/service/PaymentService.java
+++ b/src/main/java/com/be_notemasterai/payment/service/PaymentService.java
@@ -172,7 +172,7 @@ public class PaymentService {
     subscribeService.cancelSubscription(payment);
   }
 
-  private BigDecimal calculateRefundAmount(BigDecimal amount, long daysUsed) {
+  public BigDecimal calculateRefundAmount(BigDecimal amount, long daysUsed) {
 
     if (daysUsed < 1) {
       return amount;

--- a/src/main/java/com/be_notemasterai/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/be_notemasterai/security/jwt/JwtTokenProvider.java
@@ -2,6 +2,8 @@ package com.be_notemasterai.security.jwt;
 
 import static com.be_notemasterai.exception.ErrorCode.INVALID_TOKEN;
 import static io.jsonwebtoken.SignatureAlgorithm.HS256;
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 import com.be_notemasterai.exception.CustomException;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -21,8 +23,8 @@ public class JwtTokenProvider {
 
   private final Key key;
 
-  private static final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 5;
-  private static final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 7;
+  private static final long ACCESS_TOKEN_EXPIRATION = MINUTES.toSeconds(5);
+  private static final long REFRESH_TOKEN_EXPIRATION = DAYS.toSeconds(7);
 
   public JwtTokenProvider(@Value("${jwt.secret}") String secretKey) {
     this.key = Keys.hmacShaKeyFor(Base64.getDecoder().decode(secretKey));
@@ -38,7 +40,7 @@ public class JwtTokenProvider {
 
   private String createToken(String providerUuid, long expiration) {
     Date now = new Date();
-    Date expiryDate = new Date(now.getTime() + expiration);
+    Date expiryDate = new Date(now.getTime() + (expiration * 1000));
 
     return Jwts.builder()
         .setSubject(providerUuid)

--- a/src/main/java/com/be_notemasterai/security/jwt/JwtTokenService.java
+++ b/src/main/java/com/be_notemasterai/security/jwt/JwtTokenService.java
@@ -1,5 +1,6 @@
 package com.be_notemasterai.security.jwt;
 
+import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import jakarta.servlet.http.HttpServletResponse;
@@ -14,7 +15,7 @@ public class JwtTokenService {
 
   private final StringRedisTemplate redisTemplate;
 
-  private static final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 7;
+  private static final long REFRESH_TOKEN_EXPIRATION = DAYS.toSeconds(7);
 
   public void setRefreshTokenFromRedis(String providerUuid, String refreshToken) {
 

--- a/src/main/java/com/be_notemasterai/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/be_notemasterai/security/oauth2/CustomOAuth2UserService.java
@@ -1,5 +1,6 @@
 package com.be_notemasterai.security.oauth2;
 
+import static com.be_notemasterai.exception.ErrorCode.ALREADY_WITHDRAWN_MEMBER;
 import static com.be_notemasterai.exception.ErrorCode.NOT_FOUND_MEMBER;
 
 import com.be_notemasterai.exception.CustomException;
@@ -47,8 +48,14 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
   }
 
   public Member getByProviderUuid(String providerUuid) {
-    return memberRepository.findByProviderUuid(providerUuid)
+    Member member = memberRepository.findByProviderUuid(providerUuid)
         .orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
+
+    if (member.getDeletedAt() != null) {
+      throw new CustomException(ALREADY_WITHDRAWN_MEMBER);
+    }
+
+    return member;
   }
 
   private String generateTag() {

--- a/src/main/java/com/be_notemasterai/security/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/be_notemasterai/security/oauth2/OAuth2SuccessHandler.java
@@ -1,11 +1,15 @@
 package com.be_notemasterai.security.oauth2;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+import com.be_notemasterai.member.entity.Member;
 import com.be_notemasterai.security.jwt.JwtTokenProvider;
 import com.be_notemasterai.security.jwt.JwtTokenService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -21,6 +25,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
   private static final String FRONTEND_BASE_URL = "http://localhost:5173";
   private static final String DASHBOARD_URI = FRONTEND_BASE_URL + "/dashboard";
   private static final String NICKNAME_SETUP_URI = FRONTEND_BASE_URL + "/nickname-setup";
+  private static final String REJOIN_URI = FRONTEND_BASE_URL + "/rejoin";
+  private static final long TAG_EXPIRATION = MINUTES.toSeconds(5);
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -28,6 +34,23 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
     String providerUuid = principalDetails.getUsername();
+
+    Member member = principalDetails.member();
+
+    if (member.getDeletedAt() != null) {
+
+      ResponseCookie tagCookie = ResponseCookie.from("tag", member.getTag())
+          .httpOnly(true)
+          .secure(true)
+          .path("/")
+          .maxAge(TAG_EXPIRATION)
+          .build();
+
+      response.addHeader("Set-Cookie", tagCookie.toString());
+
+      response.sendRedirect(REJOIN_URI);
+      return;
+    }
 
     String refreshToken = jwtTokenProvider.createRefreshToken(providerUuid);
 

--- a/src/main/java/com/be_notemasterai/security/resolver/CurrentMemberArgumentResolver.java
+++ b/src/main/java/com/be_notemasterai/security/resolver/CurrentMemberArgumentResolver.java
@@ -1,5 +1,6 @@
 package com.be_notemasterai.security.resolver;
 
+import static com.be_notemasterai.exception.ErrorCode.ALREADY_WITHDRAWN_MEMBER;
 import static com.be_notemasterai.exception.ErrorCode.INVALID_TOKEN;
 import static com.be_notemasterai.exception.ErrorCode.NOT_FOUND_MEMBER;
 
@@ -44,7 +45,12 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
 
     PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
 
-    return memberRepository.findByProviderUuid(principalDetails.getUsername())
+    Member member = memberRepository.findByProviderUuid(principalDetails.getUsername())
         .orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
+
+    if (member.getDeletedAt() != null) {
+      throw new CustomException(ALREADY_WITHDRAWN_MEMBER);
+    }
+    return member;
   }
 }

--- a/src/main/java/com/be_notemasterai/subscribe/repository/SubscribeRepository.java
+++ b/src/main/java/com/be_notemasterai/subscribe/repository/SubscribeRepository.java
@@ -1,9 +1,13 @@
 package com.be_notemasterai.subscribe.repository;
 
+import com.be_notemasterai.member.entity.Member;
 import com.be_notemasterai.subscribe.entity.Subscribe;
 import com.be_notemasterai.subscribe.type.SubscriptionStatus;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
 
@@ -11,4 +15,9 @@ public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
       SubscriptionStatus subscriptionStatus);
 
   Optional<Subscribe> findByPaymentId(Long id);
+
+  @Query("SELECT s.endedAt FROM Subscribe s WHERE s.subscriber = :member AND s.endedAt > CURRENT_TIMESTAMP ORDER BY s.endedAt DESC LIMIT 1")
+  LocalDateTime findActiveSubscribeEndedAtBySubscriber(@Param("member") Member member);
+
+  Optional<Subscribe> findBySubscriberAndSubscriptionStatus(Member member, SubscriptionStatus subscriptionStatus);
 }

--- a/src/test/java/com/be_notemasterai/group/service/GroupServiceTest.java
+++ b/src/test/java/com/be_notemasterai/group/service/GroupServiceTest.java
@@ -4,7 +4,7 @@ import static com.be_notemasterai.exception.ErrorCode.ALREADY_SET_GROUP_MEMBER;
 import static com.be_notemasterai.exception.ErrorCode.ALREADY_SET_GROUP_NOTE;
 import static com.be_notemasterai.exception.ErrorCode.ALREADY_SET_GROUP_NULL;
 import static com.be_notemasterai.exception.ErrorCode.CANNOT_LEAVE_GROUP_AS_OWNER;
-import static com.be_notemasterai.exception.ErrorCode.EXIST_GROUP_MEMBER;
+import static com.be_notemasterai.exception.ErrorCode.EXISTS_GROUP_MEMBER;
 import static com.be_notemasterai.exception.ErrorCode.INVALID_GROUP_NOTE;
 import static com.be_notemasterai.exception.ErrorCode.NOT_FOUND_GROUP;
 import static com.be_notemasterai.exception.ErrorCode.NOT_GROUP_OWNER;
@@ -290,7 +290,7 @@ class GroupServiceTest {
     CustomException e = assertThrows(CustomException.class,
         () -> groupService.deleteGroup(owner, group.getId()));
     // then
-    assertEquals(e.getErrorCode(), EXIST_GROUP_MEMBER);
+    assertEquals(e.getErrorCode(), EXISTS_GROUP_MEMBER);
   }
 
   @Test

--- a/src/test/java/com/be_notemasterai/member/service/MemberServiceTest.java
+++ b/src/test/java/com/be_notemasterai/member/service/MemberServiceTest.java
@@ -1,16 +1,37 @@
 package com.be_notemasterai.member.service;
 
 import static com.be_notemasterai.exception.ErrorCode.ALREADY_SET_NICKNAME;
+import static com.be_notemasterai.exception.ErrorCode.EXISTS_GROUP_MEMBER;
 import static com.be_notemasterai.exception.ErrorCode.EXISTS_NICKNAME;
 import static com.be_notemasterai.exception.ErrorCode.SELF_TAG_SEARCH_NOT_ALLOWED;
+import static com.be_notemasterai.group.type.GroupRole.OWNER;
+import static com.be_notemasterai.subscribe.type.SubscriptionStatus.ACTIVE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import com.be_notemasterai.exception.CustomException;
+import com.be_notemasterai.group.entity.Group;
+import com.be_notemasterai.group.entity.GroupMember;
+import com.be_notemasterai.group.repository.GroupMemberRepository;
+import com.be_notemasterai.group.repository.GroupRepository;
+import com.be_notemasterai.group.service.GroupService;
 import com.be_notemasterai.member.dto.MemberInfoResponse;
+import com.be_notemasterai.member.dto.MemberUpdateRequest;
+import com.be_notemasterai.member.dto.MyInfoResponse;
 import com.be_notemasterai.member.entity.Member;
 import com.be_notemasterai.member.repository.MemberRepository;
+import com.be_notemasterai.note.repository.NoteRepository;
+import com.be_notemasterai.payment.entity.Payment;
+import com.be_notemasterai.payment.repository.PaymentRepository;
+import com.be_notemasterai.payment.service.PaymentService;
+import com.be_notemasterai.subscribe.entity.Subscribe;
+import com.be_notemasterai.subscribe.repository.SubscribeRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +46,27 @@ class MemberServiceTest {
 
   @Mock
   private MemberRepository memberRepository;
+
+  @Mock
+  private NoteRepository noteRepository;
+
+  @Mock
+  private GroupMemberRepository groupMemberRepository;
+
+  @Mock
+  private SubscribeRepository subscribeRepository;
+
+  @Mock
+  private PaymentService paymentService;
+
+  @Mock
+  private PaymentRepository paymentRepository;
+
+  @Mock
+  private GroupRepository groupRepository;
+
+  @Mock
+  private GroupService groupService;
 
   @InjectMocks
   private MemberService memberService;
@@ -105,5 +147,103 @@ class MemberServiceTest {
         () -> memberService.getMember(member, member.getTag()));
     // then
     assertEquals(e.getErrorCode(), SELF_TAG_SEARCH_NOT_ALLOWED);
+  }
+
+  @Test
+  @DisplayName("내 정보 조회가 성공한다")
+  void get_my_info_success() {
+    // given
+    when(noteRepository.countByOwner(member)).thenReturn(0L);
+
+    when(groupMemberRepository.countByMember(member)).thenReturn(0L);
+
+    when(subscribeRepository.findActiveSubscribeEndedAtBySubscriber(member)).thenReturn(null);
+    // when
+    MyInfoResponse myInfo = memberService.getMyInfo(member);
+    // then
+    assertEquals(myInfo.nickname(), member.getNickname());
+    assertNull(myInfo.subscribeEndedAt());
+  }
+
+  @Test
+  @DisplayName("닉네임 수정이 성공한다")
+  void update_info_success() {
+    // given
+    when(memberRepository.existsByNickname("변경")).thenReturn(false);
+    // when
+    memberService.updateInfo(member, new MemberUpdateRequest("변경"));
+    // then
+    assertEquals(member.getNickname(), "변경");
+  }
+
+  @Test
+  @DisplayName("회원 탈퇴가 성공한다")
+  void withdraw_success() {
+    // given
+    when(subscribeRepository.findBySubscriberAndSubscriptionStatus(member, ACTIVE))
+        .thenReturn(Optional.empty());
+    // when
+    memberService.withdraw(member);
+    // then
+    assertNotNull(member.getDeletedAt());
+  }
+
+  @Test
+  @DisplayName("구독이 활성화 되어있는 경우 환불 예상 금액이 반환된다")
+  void withdraw_failure_subscription_active() {
+    // given
+    Subscribe subscribe = Subscribe.builder()
+        .id(1L)
+        .subscriber(member)
+        .startedAt(LocalDateTime.now().minusDays(10))
+        .endedAt(LocalDateTime.now().plusDays(20))
+        .paymentId(1L)
+        .build();
+
+    Payment payment = Payment.builder()
+        .id(1L)
+        .member(member)
+        .amount(BigDecimal.valueOf(9900.00))
+        .build();
+    when(subscribeRepository.findBySubscriberAndSubscriptionStatus(member, ACTIVE)).thenReturn(
+        Optional.of(subscribe));
+
+    when(paymentRepository.findById(subscribe.getPaymentId())).thenReturn(Optional.of(payment));
+    // when
+    BigDecimal refundAmount = memberService.withdraw(member);
+    // then
+    assertNull(member.getDeletedAt());
+    BigDecimal expectedRefund = paymentService.calculateRefundAmount(payment.getAmount(), 10);
+    assertEquals(refundAmount, expectedRefund);
+  }
+
+  @Test
+  @DisplayName("그룹에 회원이 남아있는 경우 예외가 발생한다")
+  void withdraw_failure_exists_group_member() {
+    // given
+    Group group = Group.builder()
+        .id(1L)
+        .build();
+
+    GroupMember groupMember = GroupMember.builder()
+        .id(1L)
+        .member(member)
+        .group(group)
+        .groupRole(OWNER)
+        .build();
+
+    List<GroupMember> groupMembers = List.of(groupMember);
+
+    when(subscribeRepository.findBySubscriberAndSubscriptionStatus(member, ACTIVE))
+        .thenReturn(Optional.empty());
+
+    when(groupMemberRepository.findByMember(member)).thenReturn(groupMembers);
+
+    when(groupMemberRepository.countByGroup(group)).thenReturn(2L);
+    // when
+    CustomException e = assertThrows(CustomException.class, () -> memberService.withdraw(member));
+    // then
+    assertEquals(e.getErrorCode(), EXISTS_GROUP_MEMBER);
+    assertNull(member.getDeletedAt());
   }
 }


### PR DESCRIPTION
## 🛠️ 작업 내용 (What)
- member 관련 구현
## 📌 작업 이유 (Why)
- 회원 정보 관리 기능
## ✨ 변경 사항 (Changes)
- 내 정보 가져오기 기능
- 닉네임 수정 가능
- 회원 탈퇴 기능
  - 탈퇴 시점으로 구독중인 회원이 아니고, 그룹이 없는 경우(그룹이 있다면 본인이 그룹장인 경우 그룹에 회원이 없어야 함) 회원 탈퇴 진행
  - 회원탈퇴는 Soft Delete 처리
  - 닉네임은 다른사람이 사용할 수 있게 초기화되어 랜덤으로 변경
  - 탈퇴 시점으로 구독중이라면 환불 예정 금액 반환
- 재가입 기능
  - 소셜 로그인 진행 시 탈퇴한 회원이면 Http Only 쿠키에 회원의 고유 태그를 5분간 설정
  - 해당 태그로 재가입 진행 가능
- 소셜 로그인 시 탈퇴한 회원인지 검증하는 단계 추가
## ✅ 테스트 (Tests)
- [ ] 내 정보 조회가 성공한다
- [ ] 닉네임 수정이 성공한다
- [ ] 회원 탈퇴가 성공한다
- [ ] 구독이 활성화 되어있는 경우 환불 예상 금액이 반환된다
- [ ] 그룹에 회원이 남아있는 경우 예외가 발생한다